### PR TITLE
adding .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,25 @@
+builds:
+  - main: exporter.go
+    binary: exporter
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+      - 386
+
+archive:
+  format: tar.gz
+  files:
+    - LICENSE
+
+release:
+    github:
+        owner: nginxinc
+        name: nginx-prometheus-exporter
+
+sign:
+  artifacts: all


### PR DESCRIPTION
### Proposed changes
This adds support for `goreleaser`, which is to help build binaries for various platforms and architectures. This is so people don't have to build the binaries themselves. Other exporters are currently using this and it is super handy for the community.

Usage is:

    commit, push and tag new version (e.g. v1.1.2)
    run go get github.com/goreleaser/goreleaser (only the first time)
    export GITHUB_TOKEN=YOUR_TOKEN (generated with repo scope)
    goreleaser --rm-dist [--release-notes FILE] [--skip-publish if you want to test it] - this will build all binaries, archive them to tar.gz and create new release on github

for more info see https://goreleaser.com/

This PR was inspired by https://github.com/discordianfish/nginx_exporter/pull/35

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/master/CONTRIBUTING.md) guide
- [X] I have proven my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have ensured the README is up to date
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

