### PR TITLE
Add binaries build to Makefile and pipeline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior:
+1. Deploy using 'some_command'
+2. View logs '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Your environment**
+* Version of the Prometheus exporter - release version or a specific commit
+* Version of Docker/Kubernetes
+* [if applicable] Kubernetes platform (e.g. Mini-kube or GCP)
+* Using NGINX or NGINX Plus
+
+**Additional context**
+Add any other context about the problem here. Any log files you want to share.
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context about the feature request here.
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,9 @@ Describe the use case and detail of the change. If this PR addresses an issue on
 Before creating a PR, run through this checklist and mark each as complete.
 
 - [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/master/CONTRIBUTING.md) guide
-- [ ] I have updated the README where necessary
+- [ ] I have proven my fix is effective or that my feature works
+- [ ] I have checked that all unit tests pass after adding my changes
+- [ ] I have ensured the README is up to date
 - [ ] I have rebased my branch onto master
 - [ ] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Proposed changes
+Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue here in this description (not in the title of the PR).
+
+### Checklist
+Before creating a PR, run through this checklist and mark each as complete.
+
+- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/master/CONTRIBUTING.md) guide
+- [ ] I have updated the README where necessary
+- [ ] I have rebased my branch onto master
+- [ ] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ services:
 - docker
 go:
 - "1.10"
+script:
+- echo "Nginx Prometheus Exporter - commit:${TRAVIS_COMMIT}"
+- make test
+- make container
 before_install:
 - echo "PR Slug:${TRAVIS_PULL_REQUEST_SLUG}"
 - if [[ "${TRAVIS_PULL_REQUEST_SLUG}" == "nginxinc/nginx-prometheus-exporter" || "${TRAVIS_PULL_REQUEST}" == "false" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ script:
 - echo "Nginx Prometheus Exporter - commit:${TRAVIS_COMMIT}"
 - make test
 - make container
-- make release && echo "Nginx Prometheus exporter binaries built:" && ls -alh build/nginx-prometheus-exporter* && cat build/sha256sums.txt
 - make clean
 before_install:
 - echo "PR Slug:${TRAVIS_PULL_REQUEST_SLUG}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ script:
 - echo "Nginx Prometheus Exporter - commit:${TRAVIS_COMMIT}"
 - make test
 - make container
+- make release && echo "Nginx Prometheus exporter binaries built:" && ls -alh build/nginx-prometheus-exporter* && cat build/sha256sums.txt
+- make clean
 before_install:
 - echo "PR Slug:${TRAVIS_PULL_REQUEST_SLUG}"
 - if [[ "${TRAVIS_PULL_REQUEST_SLUG}" == "nginxinc/nginx-prometheus-exporter" || "${TRAVIS_PULL_REQUEST}" == "false" ]]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,143 @@
+# Contributing Guidelines
+
+The following is a set of guidelines for contributing to the NGINX Prometheus Exporter. We really appreciate that you are considering contributing!
+
+#### Table Of Contents
+
+[Ask a Question](#ask-a-question)
+
+[Getting Started](#getting-started)
+
+[Contributing](#contributing)
+
+[Style Guides](#style-guides)
+  * [Git Style Guide](#git-style-guide)
+  * [Go Style Guide](#go-style-guide)
+
+[Code of Conduct](#code-of-conduct)
+
+## Ask a Question
+
+We will have a public forum soon where you can come and ask questions and have a discussion. For now please open an Issue on GitHub with the label `question`.
+
+
+## Getting Started
+
+Follow our [Getting Started Guide](README.md#getting-started) to get the NGINX Prometheus Exporter up and running.
+
+### Project Structure
+
+* This Prometheus Exporter is written in Go and supports both the open source NGINX software and NGINX Plus.
+* The project dependencies reside in the `/vendor`. We use [glide](https://github.com/Masterminds/glide) for managing dependencies.
+
+## Contributing
+
+### Report a Bug
+
+To report a bug, open an issue on GitHub with the label `bug` using the available bug report issue template. Please ensure the issue has not already been reported.
+
+### Suggest an Enhancement
+
+To suggest an enhancement, please create an issue on GitHub with the label `enhancement` using the available feature issue template.
+
+### Open a Pull Request
+
+* Fork the repo, create a branch, submit a PR when your changes are tested and ready for review
+* Fill in [our pull request template](https://github.com/nginxinc/nginx-prometheus-exporter/issues/new?template=bug_report.md)
+
+Note: if you’d like to implement a new feature, please consider creating a feature request issue first to start a discussion about the feature.
+
+## Style Guides
+
+### Git Style Guide
+
+* Keep a clean, concise and meaningful git commit history on your branch, rebasing locally and squashing before submitting a PR
+* Follow the guidelines of writing a good commit message as described here https://chris.beams.io/posts/git-commit/ and summarised in the next few points
+    * In the subject line, use the present tense ("Add feature" not "Added feature")
+    * In the subject line, use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+    * Limit the subject line to 72 characters or less
+    * Reference issues and pull requests liberally after the subject line
+    * Add more detailed description in the body of the git message (`git commit -a` to give you more space and time in your text editor to write a good message instead of `git commit -am`)
+
+### Go Style Guide
+
+* Run `gofmt` over your code to automatically resolve a lot of style issues. Most editors support this running automatically when saving a code file.
+* Run `go lint` and `go vet` on your code too to catch any other issues.
+* Follow this guide on some good practice and idioms for Go -  https://github.com/golang/go/wiki/CodeReviewComments
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by this code.
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [mailto:nginx@nginx.org]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,14 @@ VERSION = 0.1.0
 PREFIX = nginx-prometheus-exporter
 TAG = $(VERSION)
 GIT_COMMIT = $(shell git rev-parse --short HEAD)
+
 BUILD_DIR = build
-test:
-	go test ./...
 
 nginx-prometheus-exporter: test
-	CGO_ENABLED=0 go build -installsuffix cgo -ldflags "-X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o nginx-prometheus-exporter .
+	CGO_ENABLED=0 go build -installsuffix cgo -ldflags "-X main.version=$(VERSION) -X main.gitCommit=$(GIT_COMMIT)" -o nginx-prometheus-exporter 
+
+test:
+	go test ./...
 
 container:
 	docker build --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) -t $(PREFIX):$(TAG) . 
@@ -16,22 +18,27 @@ push: container
 	docker push $(PREFIX):$(TAG)
 
 $(BUILD_DIR)/nginx-prometheus-exporter-linux-amd64:
-	GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -ldflags "-X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o $(BUILD_DIR)/nginx-prometheus-exporter-linux-amd64
+	GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -ldflags "-X main.version=$(VERSION) -X main.gitCommit=$(GIT_COMMIT)" -o $(BUILD_DIR)/nginx-prometheus-exporter-linux-amd64
 
 $(BUILD_DIR)/nginx-prometheus-exporter-linux-i386:
-	GOARCH=386 CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -ldflags "-X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o $(BUILD_DIR)/nginx-prometheus-exporter-linux-i386
+	GOARCH=386 CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -ldflags "-X main.version=$(VERSION) -X main.gitCommit=$(GIT_COMMIT)" -o $(BUILD_DIR)/nginx-prometheus-exporter-linux-i386
 
 release: $(BUILD_DIR)/nginx-prometheus-exporter-linux-amd64 $(BUILD_DIR)/nginx-prometheus-exporter-linux-i386
 	mv $(BUILD_DIR)/nginx-prometheus-exporter-linux-amd64 $(BUILD_DIR)/nginx-prometheus-exporter && \
-	tar czf $(BUILD_DIR)/nginx-prometheus-exporter-${TAG}-linux-amd64.tar.gz -C $(BUILD_DIR) nginx-prometheus-exporter && \
+	tar czf $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-amd64.tar.gz -C $(BUILD_DIR) nginx-prometheus-exporter && \
 	rm $(BUILD_DIR)/nginx-prometheus-exporter
+
 	mv $(BUILD_DIR)/nginx-prometheus-exporter-linux-i386 $(BUILD_DIR)/nginx-prometheus-exporter && \
-	tar czf $(BUILD_DIR)/nginx-prometheus-exporter-${TAG}-linux-i386.tar.gz -C $(BUILD_DIR) nginx-prometheus-exporter && \
+	tar czf $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-i386.tar.gz -C $(BUILD_DIR) nginx-prometheus-exporter && \
 	rm $(BUILD_DIR)/nginx-prometheus-exporter
-	echo "nginx-prometheus-exporter-${TAG}-linux-amd64.tar.gz `shasum -a 256 $(BUILD_DIR)/nginx-prometheus-exporter-${TAG}-linux-amd64.tar.gz|awk '{print $$1}'`" > $(BUILD_DIR)/sha256sums.txt
-	echo "nginx-prometheus-exporter-${TAG}-linux-i386.tar.gz  `shasum -a 256 $(BUILD_DIR)/nginx-prometheus-exporter-${TAG}-linux-i386.tar.gz|awk '{print $$1}'`" >> $(BUILD_DIR)/sha256sums.txt
+
+	echo "nginx-prometheus-exporter-$(TAG)-linux-amd64.tar.gz `shasum -a 256 $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-amd64.tar.gz|awk '{print $$1}'`" > $(BUILD_DIR)/sha256sums.txt
+	echo "nginx-prometheus-exporter-$(TAG)-linux-i386.tar.gz  `shasum -a 256 $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-i386.tar.gz|awk '{print $$1}'`" >> $(BUILD_DIR)/sha256sums.txt
 
 clean:
-	-rm -rf $(BUILD_DIR)
+	-rm $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-amd64.tar.gz
+	-rm $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-i386.tar.gz
+	-rm $(BUILD_DIR)/sha256sums.txt
+	-rmdir $(BUILD_DIR)
 	-rm nginx-prometheus-exporter
 

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,36 @@ VERSION = 0.1.0
 PREFIX = nginx-prometheus-exporter
 TAG = $(VERSION)
 GIT_COMMIT = $(shell git rev-parse --short HEAD)
-
+BUILD_DIR = build
 test:
 	go test ./...
+
+nginx-prometheus-exporter: test
+	CGO_ENABLED=0 go build -installsuffix cgo -ldflags "-X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o nginx-prometheus-exporter .
 
 container:
 	docker build --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) -t $(PREFIX):$(TAG) . 
 
 push: container
 	docker push $(PREFIX):$(TAG)
+
+$(BUILD_DIR)/nginx-prometheus-exporter-linux-amd64:
+	GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -ldflags "-X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o $(BUILD_DIR)/nginx-prometheus-exporter-linux-amd64
+
+$(BUILD_DIR)/nginx-prometheus-exporter-linux-i386:
+	GOARCH=386 CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -ldflags "-X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o $(BUILD_DIR)/nginx-prometheus-exporter-linux-i386
+
+release: $(BUILD_DIR)/nginx-prometheus-exporter-linux-amd64 $(BUILD_DIR)/nginx-prometheus-exporter-linux-i386
+	mv $(BUILD_DIR)/nginx-prometheus-exporter-linux-amd64 $(BUILD_DIR)/nginx-prometheus-exporter && \
+	tar czf $(BUILD_DIR)/nginx-prometheus-exporter-${TAG}-linux-amd64.tar.gz -C $(BUILD_DIR) nginx-prometheus-exporter && \
+	rm $(BUILD_DIR)/nginx-prometheus-exporter
+	mv $(BUILD_DIR)/nginx-prometheus-exporter-linux-i386 $(BUILD_DIR)/nginx-prometheus-exporter && \
+	tar czf $(BUILD_DIR)/nginx-prometheus-exporter-${TAG}-linux-i386.tar.gz -C $(BUILD_DIR) nginx-prometheus-exporter && \
+	rm $(BUILD_DIR)/nginx-prometheus-exporter
+	echo "nginx-prometheus-exporter-${TAG}-linux-amd64.tar.gz `shasum -a 256 $(BUILD_DIR)/nginx-prometheus-exporter-${TAG}-linux-amd64.tar.gz|awk '{print $$1}'`" > $(BUILD_DIR)/sha256sums.txt
+	echo "nginx-prometheus-exporter-${TAG}-linux-i386.tar.gz  `shasum -a 256 $(BUILD_DIR)/nginx-prometheus-exporter-${TAG}-linux-i386.tar.gz|awk '{print $$1}'`" >> $(BUILD_DIR)/sha256sums.txt
+
+clean:
+	-rm -rf $(BUILD_DIR)
+	-rm nginx-prometheus-exporter
+

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To start the exporter we use the [docker run](https://docs.docker.com/engine/ref
 
 ## Usage
 
-### Command-line Arguments 
+### Command-line Arguments
 
 ```
 Usage of ./nginx-prometheus-exporter:
@@ -54,13 +54,15 @@ Usage of ./nginx-prometheus-exporter:
   -nginx.scrape-uri string
         A URI for scraping NGINX or NGINX Plus metrics.
         For NGINX, the stub_status page must be available through the URI. For NGINX Plus -- the API. The default value can be overwritten by SCRAPE_URI environment variable. (default "http://127.0.0.1:8080/stub_status")
+  -nginx.ssl-verify
+        Perform SSL certificate verification. The default value can be overwritten by SSL_VERIFY environment variable.
   -web.listen-address string
         An address to listen on for web interface and telemetry. The default value can be overwritten by LISTEN_ADDRESS environment variable. (default ":9113")
   -web.telemetry-path string
         A path under which to expose metrics. The default value can be overwritten by TELEMETRY_PATH environment variable. (default "/metrics")
 ```
 
-### Exported Metrics 
+### Exported Metrics
 
 * For NGINX, all stub_status metrics are exported. Connect to the `/metrics` page of the running exporter to see the complete list of metrics along with their descriptions.
 * For NGINX Plus, the following metrics are exported:
@@ -69,7 +71,7 @@ Usage of ./nginx-prometheus-exporter:
     * [SSL](http://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_ssl_object).
     * [HTTP Server Zones](http://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_http_server_zone).
     * [HTTP Upsteams](http://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_http_upstream). Note: for the `state` metric, the string values are converted to float64 using the following rule: `"up"` -> `1.0`, `"draining"` -> `2.0`, `"down"` -> `3.0`, `"unavail"` –> `4.0`, `"checking"` –> `5.0`, `"unhealthy"` -> `6.0`.
-    
+
     Connect to the `/metrics` page of the running exporter to see the complete list of metrics along with their descriptions. Note: to see server zones related metrics you must configure [status zones](https://nginx.org/en/docs/http/ngx_http_status_module.html#status_zone) and to see upstream related metrics you must configure upstreams with a [shared memory zone](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#zone).
 
 ### Troubleshooting
@@ -86,10 +88,10 @@ You can build the exporter image using the provided Makefile. Before building th
 * make
 * Docker
 * git
- 
+
 To build the image, run:
 ```
-$ make container 
+$ make container
 ```
 
 Note:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ Usage of ./nginx-prometheus-exporter:
     * [HTTP](http://nginx.org/en/docs/http/ngx_http_api_module.html#http_).
     * [SSL](http://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_ssl_object).
     * [HTTP Server Zones](http://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_http_server_zone).
-    * [HTTP Upsteams](http://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_http_upstream). Note: for the `state` metric, the string values are converted to float64 using the following rule: `"up"` -> `1.0`, `"draining"` -> `2.0`, `"down"` -> `3.0`, `"unavail"` –> `4.0`, `"checking"` –> `5.0`, `"unhealthy"` -> `6.0`.
+    * [Stream Server Zones](http://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_stream_server_zone).
+    * [HTTP Upstreams](http://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_http_upstream). Note: for the `state` metric, the string values are converted to float64 using the following rule: `"up"` -> `1.0`, `"draining"` -> `2.0`, `"down"` -> `3.0`, `"unavail"` –> `4.0`, `"checking"` –> `5.0`, `"unhealthy"` -> `6.0`.
+    * [Stream Upstreams](http://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_stream_upstream). Note: for the `state` metric, the string values are converted to float64 using the following rule: `"up"` -> `1.0`, `"down"` -> `3.0`, `"unavail"` –> `4.0`, `"checking"` –> `5.0`, `"unhealthy"` -> `6.0`.
+
 
     Connect to the `/metrics` page of the running exporter to see the complete list of metrics along with their descriptions. Note: to see server zones related metrics you must configure [status zones](https://nginx.org/en/docs/http/ngx_http_status_module.html#status_zone) and to see upstream related metrics you must configure upstreams with a [shared memory zone](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#zone).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![FOSSA Status](https://app.fossa.io/api/projects/custom%2B1062%2Fgithub.com%2Fnginxinc%2Fnginx-prometheus-exporter.svg?type=shield)](https://app.fossa.io/projects/custom%2B1062%2Fgithub.com%2Fnginxinc%2Fnginx-prometheus-exporter?ref=badge_shield)
+[![Build Status](https://travis-ci.org/nginxinc/nginx-prometheus-exporter.svg?branch=master)](https://travis-ci.org/nginxinc/nginx-prometheus-exporter)  [![FOSSA Status](https://app.fossa.io/api/projects/custom%2B1062%2Fgithub.com%2Fnginxinc%2Fnginx-prometheus-exporter.svg?type=shield)](https://app.fossa.io/projects/custom%2B1062%2Fgithub.com%2Fnginxinc%2Fnginx-prometheus-exporter?ref=badge_shield)
 
 # NGINX Prometheus Exporter
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/nginxinc/nginx-prometheus-exporter.svg?branch=master)](https://travis-ci.org/nginxinc/nginx-prometheus-exporter)  [![FOSSA Status](https://app.fossa.io/api/projects/custom%2B1062%2Fgithub.com%2Fnginxinc%2Fnginx-prometheus-exporter.svg?type=shield)](https://app.fossa.io/projects/custom%2B1062%2Fgithub.com%2Fnginxinc%2Fnginx-prometheus-exporter?ref=badge_shield)
+[![Build Status](https://travis-ci.org/nginxinc/nginx-prometheus-exporter.svg?branch=master)](https://travis-ci.org/nginxinc/nginx-prometheus-exporter)  [![FOSSA Status](https://app.fossa.io/api/projects/custom%2B1062%2Fgithub.com%2Fnginxinc%2Fnginx-prometheus-exporter.svg?type=shield)](https://app.fossa.io/projects/custom%2B1062%2Fgithub.com%2Fnginxinc%2Fnginx-prometheus-exporter?ref=badge_shield)  [![Go Report Card](https://goreportcard.com/badge/github.com/nginxinc/nginx-prometheus-exporter)](https://goreportcard.com/report/github.com/nginxinc/nginx-prometheus-exporter)
 
 # NGINX Prometheus Exporter
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To start the exporter we use the [docker run](https://docs.docker.com/engine/ref
 
 * To export NGINX metrics, run:
     ```
-    $ docker run -p 9113:9113 nginx/nginx-prometheus-exporter:0.1.0 -nginx.scrape-uri http://<nginx>:8080/api
+    $ docker run -p 9113:9113 nginx/nginx-prometheus-exporter:0.1.0 -nginx.scrape-uri http://<nginx>:8080/stub_status
     ```
     where `<nginx>` is the IP address/DNS name, through which NGINX is available.
 

--- a/collector/nginx_plus.go
+++ b/collector/nginx_plus.go
@@ -4,19 +4,19 @@ import (
 	"log"
 	"sync"
 
-	"github.com/nginxinc/nginx-prometheus-exporter/client"
+	plusclient "github.com/nginxinc/nginx-plus-go-sdk/client"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // NginxPlusCollector collects NGINX Plus metrics. It implements prometheus.Collector interface.
 type NginxPlusCollector struct {
-	nginxClient                                                             *client.NginxPlusClient
+	nginxClient                                                             *plusclient.NginxClient
 	totalMetrics, serverZoneMetrics, upstreamMetrics, upstreamServerMetrics map[string]*prometheus.Desc
 	mutex                                                                   sync.Mutex
 }
 
 // NewNginxPlusCollector creates an NginxPlusCollector.
-func NewNginxPlusCollector(nginxClient *client.NginxPlusClient, namespace string) *NginxPlusCollector {
+func NewNginxPlusCollector(nginxClient *plusclient.NginxClient, namespace string) *NginxPlusCollector {
 	return &NginxPlusCollector{
 		nginxClient: nginxClient,
 		totalMetrics: map[string]*prometheus.Desc{
@@ -169,7 +169,7 @@ func (c *NginxPlusCollector) Collect(ch chan<- prometheus.Metric) {
 			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["response_time"],
 				prometheus.GaugeValue, float64(peer.ResponseTime), name, peer.Server)
 
-			if peer.HealthChecks != (client.HealthChecks{}) {
+			if peer.HealthChecks != (plusclient.HealthChecks{}) {
 				ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["health_checks_checks"],
 					prometheus.CounterValue, float64(peer.HealthChecks.Checks), name, peer.Server)
 				ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["health_checks_fails"],

--- a/collector/nginx_plus.go
+++ b/collector/nginx_plus.go
@@ -10,9 +10,15 @@ import (
 
 // NginxPlusCollector collects NGINX Plus metrics. It implements prometheus.Collector interface.
 type NginxPlusCollector struct {
-	nginxClient                                                             *plusclient.NginxClient
-	totalMetrics, serverZoneMetrics, upstreamMetrics, upstreamServerMetrics map[string]*prometheus.Desc
-	mutex                                                                   sync.Mutex
+	nginxClient                 *plusclient.NginxClient
+	totalMetrics                map[string]*prometheus.Desc
+	serverZoneMetrics           map[string]*prometheus.Desc
+	upstreamMetrics             map[string]*prometheus.Desc
+	upstreamServerMetrics       map[string]*prometheus.Desc
+	streamServerZoneMetrics     map[string]*prometheus.Desc
+	streamUpstreamMetrics       map[string]*prometheus.Desc
+	streamUpstreamServerMetrics map[string]*prometheus.Desc
+	mutex                       sync.Mutex
 }
 
 // NewNginxPlusCollector creates an NginxPlusCollector.
@@ -42,9 +48,22 @@ func NewNginxPlusCollector(nginxClient *plusclient.NginxClient, namespace string
 			"received":      newServerZoneMetric(namespace, "received", "Bytes received from clients", nil),
 			"sent":          newServerZoneMetric(namespace, "sent", "Bytes sent to clients", nil),
 		},
+		streamServerZoneMetrics: map[string]*prometheus.Desc{
+			"processing":   newStreamServerZoneMetric(namespace, "processing", "Client connections that are currently being processed", nil),
+			"connections":  newStreamServerZoneMetric(namespace, "connections", "Total connections", nil),
+			"sessions_2xx": newStreamServerZoneMetric(namespace, "sessions", "Total sessions completed", prometheus.Labels{"code": "2xx"}),
+			"sessions_4xx": newStreamServerZoneMetric(namespace, "sessions", "Total sessions completed", prometheus.Labels{"code": "4xx"}),
+			"sessions_5xx": newStreamServerZoneMetric(namespace, "sessions", "Total sessions completed", prometheus.Labels{"code": "5xx"}),
+			"discarded":    newStreamServerZoneMetric(namespace, "discarded", "Connections completed without creating a session", nil),
+			"received":     newStreamServerZoneMetric(namespace, "received", "Bytes received from clients", nil),
+			"sent":         newStreamServerZoneMetric(namespace, "sent", "Bytes sent to clients", nil),
+		},
 		upstreamMetrics: map[string]*prometheus.Desc{
 			"keepalives": newUpstreamMetric(namespace, "keepalives", "Idle keepalive connections"),
 			"zombies":    newUpstreamMetric(namespace, "zombies", "Servers removed from the group but still processing active client requests"),
+		},
+		streamUpstreamMetrics: map[string]*prometheus.Desc{
+			"zombies": newStreamUpstreamMetric(namespace, "zombies", "Servers removed from the group but still processing active client connections"),
 		},
 		upstreamServerMetrics: map[string]*prometheus.Desc{
 			"state":                   newUpstreamServerMetric(namespace, "state", "Current state", nil),
@@ -65,6 +84,21 @@ func NewNginxPlusCollector(nginxClient *plusclient.NginxClient, namespace string
 			"health_checks_fails":     newUpstreamServerMetric(namespace, "health_checks_fails", "Failed health checks", nil),
 			"health_checks_unhealthy": newUpstreamServerMetric(namespace, "health_checks_unhealthy", "How many times the server became unhealthy (state 'unhealthy')", nil),
 		},
+		streamUpstreamServerMetrics: map[string]*prometheus.Desc{
+			"state":                   newStreamUpstreamServerMetric(namespace, "state", "Current state"),
+			"active":                  newStreamUpstreamServerMetric(namespace, "active", "Active connections"),
+			"sent":                    newStreamUpstreamServerMetric(namespace, "sent", "Bytes sent to this server"),
+			"received":                newStreamUpstreamServerMetric(namespace, "received", "Bytes received from this server"),
+			"fails":                   newStreamUpstreamServerMetric(namespace, "fails", "Number of unsuccessful attempts to communicate with the server"),
+			"unavail":                 newStreamUpstreamServerMetric(namespace, "unavail", "How many times the server became unavailable for client connections (state 'unavail') due to the number of unsuccessful attempts reaching the max_fails threshold"),
+			"connections":             newStreamUpstreamServerMetric(namespace, "connections", "Total number of client connections forwarded to this server"),
+			"connect_time":            newStreamUpstreamServerMetric(namespace, "connect_time", "Average time to connect to the upstream server"),
+			"first_byte_time":         newStreamUpstreamServerMetric(namespace, "first_byte_time", "Average time to receive the first byte of data"),
+			"response_time":           newStreamUpstreamServerMetric(namespace, "response_time", "Average time to receive the last byte of data"),
+			"health_checks_checks":    newStreamUpstreamServerMetric(namespace, "health_checks_checks", "Total health check requests"),
+			"health_checks_fails":     newStreamUpstreamServerMetric(namespace, "health_checks_fails", "Failed health checks"),
+			"health_checks_unhealthy": newStreamUpstreamServerMetric(namespace, "health_checks_unhealthy", "How many times the server became unhealthy (state 'unhealthy')"),
+		},
 	}
 }
 
@@ -81,6 +115,15 @@ func (c *NginxPlusCollector) Describe(ch chan<- *prometheus.Desc) {
 		ch <- m
 	}
 	for _, m := range c.upstreamServerMetrics {
+		ch <- m
+	}
+	for _, m := range c.streamServerZoneMetrics {
+		ch <- m
+	}
+	for _, m := range c.streamUpstreamMetrics {
+		ch <- m
+	}
+	for _, m := range c.streamUpstreamServerMetrics {
 		ch <- m
 	}
 }
@@ -138,6 +181,25 @@ func (c *NginxPlusCollector) Collect(ch chan<- prometheus.Metric) {
 			prometheus.CounterValue, float64(zone.Sent), name)
 	}
 
+	for name, zone := range stats.StreamServerZones {
+		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["processing"],
+			prometheus.GaugeValue, float64(zone.Processing), name)
+		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["connections"],
+			prometheus.CounterValue, float64(zone.Connections), name)
+		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["sessions_2xx"],
+			prometheus.CounterValue, float64(zone.Sessions.Sessions2xx), name)
+		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["sessions_4xx"],
+			prometheus.CounterValue, float64(zone.Sessions.Sessions4xx), name)
+		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["sessions_5xx"],
+			prometheus.CounterValue, float64(zone.Sessions.Sessions5xx), name)
+		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["discarded"],
+			prometheus.CounterValue, float64(zone.Discarded), name)
+		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["received"],
+			prometheus.CounterValue, float64(zone.Received), name)
+		ch <- prometheus.MustNewConstMetric(c.streamServerZoneMetrics["sent"],
+			prometheus.CounterValue, float64(zone.Sent), name)
+	}
+
 	for name, upstream := range stats.Upstreams {
 		for _, peer := range upstream.Peers {
 			ch <- prometheus.MustNewConstMetric(c.upstreamServerMetrics["state"],
@@ -183,6 +245,41 @@ func (c *NginxPlusCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(c.upstreamMetrics["zombies"],
 			prometheus.GaugeValue, float64(upstream.Zombies), name)
 	}
+
+	for name, upstream := range stats.StreamUpstreams {
+		for _, peer := range upstream.Peers {
+			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["state"],
+				prometheus.GaugeValue, upstreamServerStates[peer.State], name, peer.Server)
+			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["active"],
+				prometheus.GaugeValue, float64(peer.Active), name, peer.Server)
+			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["connections"],
+				prometheus.CounterValue, float64(peer.Connections), name, peer.Server)
+			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["connect_time"],
+				prometheus.GaugeValue, float64(peer.ConnectTime), name, peer.Server)
+			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["first_byte_time"],
+				prometheus.GaugeValue, float64(peer.FirstByteTime), name, peer.Server)
+			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["response_time"],
+				prometheus.GaugeValue, float64(peer.ResponseTime), name, peer.Server)
+			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["sent"],
+				prometheus.CounterValue, float64(peer.Sent), name, peer.Server)
+			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["received"],
+				prometheus.CounterValue, float64(peer.Received), name, peer.Server)
+			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["fails"],
+				prometheus.CounterValue, float64(peer.Fails), name, peer.Server)
+			ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["unavail"],
+				prometheus.CounterValue, float64(peer.Unavail), name, peer.Server)
+			if peer.HealthChecks != (plusclient.HealthChecks{}) {
+				ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["health_checks_checks"],
+					prometheus.CounterValue, float64(peer.HealthChecks.Checks), name, peer.Server)
+				ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["health_checks_fails"],
+					prometheus.CounterValue, float64(peer.HealthChecks.Fails), name, peer.Server)
+				ch <- prometheus.MustNewConstMetric(c.streamUpstreamServerMetrics["health_checks_unhealthy"],
+					prometheus.CounterValue, float64(peer.HealthChecks.Unhealthy), name, peer.Server)
+			}
+		}
+		ch <- prometheus.MustNewConstMetric(c.streamUpstreamMetrics["zombies"],
+			prometheus.GaugeValue, float64(upstream.Zombies), name)
+	}
 }
 
 var upstreamServerStates = map[string]float64{
@@ -198,10 +295,22 @@ func newServerZoneMetric(namespace string, metricName string, docString string, 
 	return prometheus.NewDesc(prometheus.BuildFQName(namespace, "server_zone", metricName), docString, []string{"server_zone"}, constLabels)
 }
 
+func newStreamServerZoneMetric(namespace string, metricName string, docString string, constLabels prometheus.Labels) *prometheus.Desc {
+	return prometheus.NewDesc(prometheus.BuildFQName(namespace, "stream_server_zone", metricName), docString, []string{"server_zone"}, constLabels)
+}
+
 func newUpstreamMetric(namespace string, metricName string, docString string) *prometheus.Desc {
 	return prometheus.NewDesc(prometheus.BuildFQName(namespace, "upstream", metricName), docString, []string{"upstream"}, nil)
 }
 
+func newStreamUpstreamMetric(namespace string, metricName string, docString string) *prometheus.Desc {
+	return prometheus.NewDesc(prometheus.BuildFQName(namespace, "stream_upstream", metricName), docString, []string{"upstream"}, nil)
+}
+
 func newUpstreamServerMetric(namespace string, metricName string, docString string, constLabels prometheus.Labels) *prometheus.Desc {
 	return prometheus.NewDesc(prometheus.BuildFQName(namespace, "upstream_server", metricName), docString, []string{"upstream", "server"}, constLabels)
+}
+
+func newStreamUpstreamServerMetric(namespace string, metricName string, docString string) *prometheus.Desc {
+	return prometheus.NewDesc(prometheus.BuildFQName(namespace, "stream_upstream_server", metricName), docString, []string{"upstream", "server"}, nil)
 }

--- a/exporter.go
+++ b/exporter.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 
+	plusclient "github.com/nginxinc/nginx-plus-go-sdk/client"
 	"github.com/nginxinc/nginx-prometheus-exporter/client"
 	"github.com/nginxinc/nginx-prometheus-exporter/collector"
 	"github.com/prometheus/client_golang/prometheus"
@@ -64,7 +65,7 @@ func main() {
 	registry := prometheus.NewRegistry()
 
 	if *nginxPlus {
-		client, err := client.NewNginxPlusClient(&http.Client{}, *scrapeURI)
+		client, err := plusclient.NewNginxClient(&http.Client{}, *scrapeURI)
 		if err != nil {
 			log.Fatalf("Could not create Nginx Plus Client: %v", err)
 		}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b62c6e250515f52280a59752a7075ef981a91b95b5f4c745d101b9eded3b217d
-updated: 2018-02-16T19:25:05.201189672Z
+hash: d521449fd1ccbcc6752cf851621a7738de377698fd2b946e863909082454e5ff
+updated: 2018-09-10T15:23:48.284293+01:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -13,6 +13,10 @@ imports:
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
+- name: github.com/nginxinc/nginx-plus-go-sdk
+  version: 47154e1ef11536726753d5f506babe9304d622d2
+  subpackages:
+  - client
 - name: github.com/prometheus/client_golang
   version: e69720d204a4aa3b0c65dc91208645ba0a52b9cd
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,3 +4,7 @@ import:
   subpackages:
   - prometheus
   - prometheus/promhttp
+- package: github.com/nginxinc/nginx-plus-go-sdk
+  version: v0.2
+  subpackages:
+  - client

--- a/vendor/github.com/nginxinc/nginx-plus-go-sdk/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/vendor/github.com/nginxinc/nginx-plus-go-sdk/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+Steps to reproduce the behavior, such as:
+1. Try adding upstream through the client
+2. Returns a panic
+3. Here is the stacktrace
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Your environment**
+* Version of nginx-plus-go-sdk
+* Version of NGINX Plus
+* Version of the OS
+
+**Additional context**
+Add any other context about the problem here.

--- a/vendor/github.com/nginxinc/nginx-plus-go-sdk/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/vendor/github.com/nginxinc/nginx-plus-go-sdk/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context about the feature request here.

--- a/vendor/github.com/nginxinc/nginx-plus-go-sdk/.github/PULL_REQUEST_TEMPLATE.md
+++ b/vendor/github.com/nginxinc/nginx-plus-go-sdk/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+### Proposed changes
+Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue here in this description (not in the title of the PR).
+
+### Checklist
+Before creating a PR, run through this checklist and mark each as complete.
+
+- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-plus-go-sdk/blob/master/CONTRIBUTING.md) doc
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have checked that all unit tests pass after adding my changes
+- [ ] I have updated necessary documentation
+- [ ] I have rebased my branch onto master
+- [ ] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork

--- a/vendor/github.com/nginxinc/nginx-plus-go-sdk/.gitignore
+++ b/vendor/github.com/nginxinc/nginx-plus-go-sdk/.gitignore
@@ -1,0 +1,6 @@
+# NGINX Plus license files
+*.crt
+*.key
+
+# Visual Studio Code settings
+.vscode

--- a/vendor/github.com/nginxinc/nginx-plus-go-sdk/CHANGELOG.md
+++ b/vendor/github.com/nginxinc/nginx-plus-go-sdk/CHANGELOG.md
@@ -1,0 +1,10 @@
+## 0.2 (Sep 7, 2018)
+
+FEATURES:
+* [7](https://github.com/nginxinc/nginx-plus-go-sdk/pull/7): *Support for stream server zone and stream upstream metrics*. The client `GetStats` method now additionally returns stream server zone and stream upstream metrics.
+
+CHANGES:
+* The version of NGINX Plus for e2e testing was changed to R16.
+
+## 0.1 (July 30, 2018)
+Initial release

--- a/vendor/github.com/nginxinc/nginx-plus-go-sdk/CONTRIBUTING.md
+++ b/vendor/github.com/nginxinc/nginx-plus-go-sdk/CONTRIBUTING.md
@@ -1,0 +1,138 @@
+# Contributing Guidelines
+
+The following is a set of guidelines for contributing to the NGINX Plus Go SDK. We really appreciate that you are considering contributing!
+
+#### Table Of Contents
+
+[Ask a Question](#ask-a-question)
+
+[Getting Started](#getting-started)
+
+[Contributing](#contributing)
+
+[Style Guides](#style-guides)
+  * [Git Style Guide](#git-style-guide)
+  * [Go Style Guide](#go-style-guide)
+
+[Code of Conduct](#code-of-conduct)
+
+## Ask a Question
+
+We will have a public forum soon where you can come and ask questions and have a discussion. For now please open an Issue on GitHub with the label `question`.
+
+
+## Getting Started
+
+Read the usage and testing steps in the [README](README.md).
+
+
+## Contributing
+
+### Report a Bug
+
+To report a bug, open an issue on GitHub with the label `bug` using the available bug report issue template. Please ensure the issue has not already been reported.
+
+### Suggest an Enhancement
+
+To suggest an enhancement, please create an issue on GitHub with the label `enhancement` using the available feature issue template.
+
+### Open a Pull Request
+
+* Fork the repo, create a branch, submit a PR when your changes are tested and ready for review
+* You will be asked to fill in [our pull request template](.github/ISSUE_TEMPLATE/PULL_REQUEST_TEMPLATE.md)
+
+Note: if you’d like to implement a new feature, please consider creating a feature request issue first to start a discussion about the feature.
+
+## Style Guides
+
+### Git Style Guide
+
+* Keep a clean, concise and meaningful git commit history on your branch, rebasing locally and squashing before submitting a PR
+* Follow the guidelines of writing a good commit message as described here https://chris.beams.io/posts/git-commit/ and summarised in the next few points
+    * In the subject line, use the present tense ("Add feature" not "Added feature")
+    * In the subject line, use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+    * Limit the subject line to 72 characters or less
+    * Reference issues and pull requests liberally after the subject line
+    * Add more detailed description in the body of the git message (`git commit -a` to give you more space and time in your text editor to write a good message instead of `git commit -am`)
+
+### Go Style Guide
+
+* Run `gofmt` over your code to automatically resolve a lot of style issues. Most editors support this running automatically when saving a code file.
+* Run `go lint` and `go vet` on your code too to catch any other issues.
+* Follow this guide on some good practice and idioms for Go -  https://github.com/golang/go/wiki/CodeReviewComments
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by this code.
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [mailto:nginx@nginx.org]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/vendor/github.com/nginxinc/nginx-plus-go-sdk/LICENSE
+++ b/vendor/github.com/nginxinc/nginx-plus-go-sdk/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "{}"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2018 Nginx, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/nginxinc/nginx-plus-go-sdk/Makefile
+++ b/vendor/github.com/nginxinc/nginx-plus-go-sdk/Makefile
@@ -1,0 +1,24 @@
+NGINX_PLUS_VERSION=16-1
+NGINX_IMAGE=nginxplus:$(NGINX_PLUS_VERSION)
+
+test: docker-build run-nginx-plus test-run configure-no-stream-block test-run-no-stream-block clean
+
+docker-build:
+	docker build --build-arg NGINX_PLUS_VERSION=$(NGINX_PLUS_VERSION)~stretch -t $(NGINX_IMAGE) docker
+
+run-nginx-plus:
+	docker run -d --name nginx-plus-test --rm -p 8080:8080 -p 8081:8081 $(NGINX_IMAGE)
+
+test-run:
+	go test client/*
+	GOCACHE=off go test tests/client_test.go
+
+configure-no-stream-block:
+	docker cp docker/nginx_no_stream.conf nginx-plus-test:/etc/nginx/nginx.conf
+	docker exec nginx-plus-test nginx -s reload
+
+test-run-no-stream-block:
+	GOCACHE=off go test tests/client_no_stream_test.go
+
+clean:
+	docker kill nginx-plus-test

--- a/vendor/github.com/nginxinc/nginx-plus-go-sdk/README.md
+++ b/vendor/github.com/nginxinc/nginx-plus-go-sdk/README.md
@@ -1,0 +1,43 @@
+# NGINX Plus API Go SDK
+
+This SDK includes a client library for working with NGINX Plus API.
+
+## About the SDK
+
+`client/nginx.go` includes functions and data structures for working with NGINX Plus API as well as some helper functions.
+
+## Compatibility
+
+This SDK works against version 2 of NGINX Plus API. Version 2 was introduced in NGINX Plus R14.
+
+## Using the SDK
+
+1. Import `github.com/nginxinc/nginx-plus-go-sdk/client` into your go project.
+2. Use your favourite vendor tool to add this to your `/vendor` directory in your project.
+
+## Testing
+
+### Unit tests
+```
+$ cd client
+$ go test
+```
+
+### Integration tests
+
+Prerequisites:
+* Docker
+* golang
+* Make
+* NGINX Plus license - put `nginx-repo.crt` and `nginx-repo.key` into the `docker` folder.
+
+Run Tests:
+
+```
+$ make test
+```
+
+This will build and run an NGINX Plus container, execute the SDK tests against NGINX Plus API, and then clean up. If it fails and you want to clean up (i.e. stop the running container), please use `$ make clean`
+
+## Support
+This project is not covered by the NGINX Plus support contract.

--- a/vendor/github.com/nginxinc/nginx-plus-go-sdk/client/nginx_test.go
+++ b/vendor/github.com/nginxinc/nginx-plus-go-sdk/client/nginx_test.go
@@ -1,0 +1,232 @@
+package client
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDetermineUpdates(t *testing.T) {
+	var tests = []struct {
+		updated          []UpstreamServer
+		nginx            []UpstreamServer
+		expectedToAdd    []UpstreamServer
+		expectedToDelete []UpstreamServer
+	}{{
+		updated: []UpstreamServer{
+			UpstreamServer{
+				Server: "10.0.0.3:80",
+			},
+			UpstreamServer{
+				Server: "10.0.0.4:80",
+			},
+		},
+		nginx: []UpstreamServer{
+			UpstreamServer{
+				ID:     1,
+				Server: "10.0.0.1:80",
+			},
+			UpstreamServer{
+				ID:     2,
+				Server: "10.0.0.2:80",
+			},
+		},
+		expectedToAdd: []UpstreamServer{
+			UpstreamServer{
+				Server: "10.0.0.3:80",
+			},
+			UpstreamServer{
+				Server: "10.0.0.4:80",
+			},
+		},
+		expectedToDelete: []UpstreamServer{
+			UpstreamServer{
+				ID:     1,
+				Server: "10.0.0.1:80",
+			},
+			UpstreamServer{
+				ID:     2,
+				Server: "10.0.0.2:80",
+			},
+		}}, {
+		updated: []UpstreamServer{
+			UpstreamServer{
+				Server: "10.0.0.2:80",
+			},
+			UpstreamServer{
+				Server: "10.0.0.3:80",
+			},
+			UpstreamServer{
+				Server: "10.0.0.4:80",
+			},
+		},
+		nginx: []UpstreamServer{
+			UpstreamServer{
+				ID:     1,
+				Server: "10.0.0.1:80",
+			},
+			UpstreamServer{
+				ID:     2,
+				Server: "10.0.0.2:80",
+			},
+			UpstreamServer{
+				ID:     3,
+				Server: "10.0.0.3:80",
+			},
+		},
+		expectedToAdd: []UpstreamServer{
+			UpstreamServer{
+				Server: "10.0.0.4:80",
+			}},
+		expectedToDelete: []UpstreamServer{
+			UpstreamServer{
+				ID:     1,
+				Server: "10.0.0.1:80",
+			}},
+	}, {
+		updated: []UpstreamServer{
+			UpstreamServer{
+				Server: "10.0.0.1:80",
+			},
+			UpstreamServer{
+				Server: "10.0.0.2:80",
+			},
+			UpstreamServer{
+				Server: "10.0.0.3:80",
+			}},
+		nginx: []UpstreamServer{
+			UpstreamServer{
+				ID:     1,
+				Server: "10.0.0.1:80",
+			},
+			UpstreamServer{
+				ID:     2,
+				Server: "10.0.0.2:80",
+			},
+			UpstreamServer{
+				ID:     3,
+				Server: "10.0.0.3:80",
+			},
+		}}, {
+		// empty values
+	}}
+
+	for _, test := range tests {
+		toAdd, toDelete := determineUpdates(test.updated, test.nginx)
+		if !reflect.DeepEqual(toAdd, test.expectedToAdd) || !reflect.DeepEqual(toDelete, test.expectedToDelete) {
+			t.Errorf("determiteUpdates(%v, %v) = (%v, %v)", test.updated, test.nginx, toAdd, toDelete)
+		}
+	}
+}
+
+func TestStreamDetermineUpdates(t *testing.T) {
+	var tests = []struct {
+		updated          []StreamUpstreamServer
+		nginx            []StreamUpstreamServer
+		expectedToAdd    []StreamUpstreamServer
+		expectedToDelete []StreamUpstreamServer
+	}{{
+		updated: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				Server: "10.0.0.3:80",
+			},
+			StreamUpstreamServer{
+				Server: "10.0.0.4:80",
+			},
+		},
+		nginx: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				ID:     1,
+				Server: "10.0.0.1:80",
+			},
+			StreamUpstreamServer{
+				ID:     2,
+				Server: "10.0.0.2:80",
+			},
+		},
+		expectedToAdd: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				Server: "10.0.0.3:80",
+			},
+			StreamUpstreamServer{
+				Server: "10.0.0.4:80",
+			},
+		},
+		expectedToDelete: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				ID:     1,
+				Server: "10.0.0.1:80",
+			},
+			StreamUpstreamServer{
+				ID:     2,
+				Server: "10.0.0.2:80",
+			},
+		}}, {
+		updated: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				Server: "10.0.0.2:80",
+			},
+			StreamUpstreamServer{
+				Server: "10.0.0.3:80",
+			},
+			StreamUpstreamServer{
+				Server: "10.0.0.4:80",
+			},
+		},
+		nginx: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				ID:     1,
+				Server: "10.0.0.1:80",
+			},
+			StreamUpstreamServer{
+				ID:     2,
+				Server: "10.0.0.2:80",
+			},
+			StreamUpstreamServer{
+				ID:     3,
+				Server: "10.0.0.3:80",
+			},
+		},
+		expectedToAdd: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				Server: "10.0.0.4:80",
+			}},
+		expectedToDelete: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				ID:     1,
+				Server: "10.0.0.1:80",
+			}},
+	}, {
+		updated: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				Server: "10.0.0.1:80",
+			},
+			StreamUpstreamServer{
+				Server: "10.0.0.2:80",
+			},
+			StreamUpstreamServer{
+				Server: "10.0.0.3:80",
+			}},
+		nginx: []StreamUpstreamServer{
+			StreamUpstreamServer{
+				ID:     1,
+				Server: "10.0.0.1:80",
+			},
+			StreamUpstreamServer{
+				ID:     2,
+				Server: "10.0.0.2:80",
+			},
+			StreamUpstreamServer{
+				ID:     3,
+				Server: "10.0.0.3:80",
+			},
+		}}, {
+		// empty values
+	}}
+
+	for _, test := range tests {
+		toAdd, toDelete := determineStreamUpdates(test.updated, test.nginx)
+		if !reflect.DeepEqual(toAdd, test.expectedToAdd) || !reflect.DeepEqual(toDelete, test.expectedToDelete) {
+			t.Errorf("determiteUpdates(%v, %v) = (%v, %v)", test.updated, test.nginx, toAdd, toDelete)
+		}
+	}
+}

--- a/vendor/github.com/nginxinc/nginx-plus-go-sdk/docker/Dockerfile
+++ b/vendor/github.com/nginxinc/nginx-plus-go-sdk/docker/Dockerfile
@@ -1,0 +1,56 @@
+FROM debian:stretch-slim
+
+LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
+
+ARG NGINX_PLUS_VERSION
+
+# Download certificate and key from the customer portal (https://cs.nginx.com)
+# and copy to the build context
+COPY nginx-repo.crt /etc/ssl/nginx/
+COPY nginx-repo.key /etc/ssl/nginx/
+
+# Make sure the certificate and key have correct permissions
+RUN chmod 644 /etc/ssl/nginx/*
+
+# Install NGINX Plus
+RUN set -x \
+  && apt-get update \
+  && apt-get install --no-install-recommends --no-install-suggests -y apt-transport-https ca-certificates gnupg1 \
+  && \
+  NGINX_GPGKEY=573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62; \
+  found=''; \
+  for server in \
+    ha.pool.sks-keyservers.net \
+    hkp://keyserver.ubuntu.com:80 \
+    hkp://p80.pool.sks-keyservers.net:80 \
+    pgp.mit.edu \
+  ; do \
+    echo "Fetching GPG key $NGINX_GPGKEY from $server"; \
+    apt-key adv --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$NGINX_GPGKEY" && found=yes && break; \
+  done; \
+  test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
+  echo "Acquire::https::plus-pkgs.nginx.com::Verify-Peer \"true\";" >> /etc/apt/apt.conf.d/90nginx \
+  && echo "Acquire::https::plus-pkgs.nginx.com::Verify-Host \"true\";" >> /etc/apt/apt.conf.d/90nginx \
+  && echo "Acquire::https::plus-pkgs.nginx.com::SslCert     \"/etc/ssl/nginx/nginx-repo.crt\";" >> /etc/apt/apt.conf.d/90nginx \
+  && echo "Acquire::https::plus-pkgs.nginx.com::SslKey      \"/etc/ssl/nginx/nginx-repo.key\";" >> /etc/apt/apt.conf.d/90nginx \
+  && printf "deb https://plus-pkgs.nginx.com/debian stretch nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
+  && apt-get update && apt-get install -y nginx-plus=${NGINX_PLUS_VERSION} \
+  && apt-get remove --purge --auto-remove -y gnupg1 \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /etc/ssl/nginx \
+  && rm /etc/apt/apt.conf.d/90nginx /etc/apt/sources.list.d/nginx-plus.list
+
+
+# Forward request logs to Docker log collector
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+  && ln -sf /dev/stderr /var/log/nginx/error.log
+
+EXPOSE 80
+
+STOPSIGNAL SIGTERM
+
+RUN rm -rf /etc/nginx/conf.d/*
+COPY test.conf /etc/nginx/conf.d/
+COPY nginx.conf /etc/nginx/
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/vendor/github.com/nginxinc/nginx-plus-go-sdk/docker/nginx.conf
+++ b/vendor/github.com/nginxinc/nginx-plus-go-sdk/docker/nginx.conf
@@ -1,0 +1,46 @@
+
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}
+
+stream {
+    upstream stream_test {
+        zone stream_test 64k;
+    }
+
+    server {
+        listen 8081;
+        proxy_pass stream_test;
+        status_zone stream_test;
+        health_check interval=10 fails=3 passes=1;
+    }
+
+}

--- a/vendor/github.com/nginxinc/nginx-plus-go-sdk/docker/nginx_no_stream.conf
+++ b/vendor/github.com/nginxinc/nginx-plus-go-sdk/docker/nginx_no_stream.conf
@@ -1,0 +1,32 @@
+
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/vendor/github.com/nginxinc/nginx-plus-go-sdk/docker/test.conf
+++ b/vendor/github.com/nginxinc/nginx-plus-go-sdk/docker/test.conf
@@ -1,0 +1,25 @@
+upstream test {
+    zone test 64k;
+}
+
+server {
+    listen 8080;
+
+    location = /dashboard.html {
+        root /usr/share/nginx/html;
+    }
+
+    location /api {
+        limit_except GET {
+            allow 172.0.0.0/8;
+            deny all;
+        }
+        api write=on;
+    }
+
+    location /test {
+        proxy_pass http://test;
+        health_check interval=10 fails=3 passes=1;
+    }
+    status_zone test;
+}

--- a/vendor/github.com/nginxinc/nginx-plus-go-sdk/tests/client_no_stream_test.go
+++ b/vendor/github.com/nginxinc/nginx-plus-go-sdk/tests/client_no_stream_test.go
@@ -1,0 +1,37 @@
+package tests
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/nginxinc/nginx-plus-go-sdk/client"
+)
+
+// TestStatsNoStream tests the peculiar behavior of getting Stream-related
+// stats from the API when there are no stream blocks in the config.
+// The API returns a special error code that we can use to determine if the API
+// is misconfigured or of the stream block is missing.
+func TestStatsNoStream(t *testing.T) {
+	httpClient := &http.Client{}
+	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
+	if err != nil {
+		t.Fatalf("Error connecting to nginx: %v", err)
+	}
+
+	stats, err := c.GetStats()
+	if err != nil {
+		t.Errorf("Error getting stats: %v", err)
+	}
+
+	if stats.Connections.Accepted < 1 {
+		t.Errorf("Stats should report some connections: %v", stats.Connections)
+	}
+
+	if len(stats.StreamServerZones) != 0 {
+		t.Error("No stream block should result in no StreamServerZones")
+	}
+
+	if len(stats.StreamUpstreams) != 0 {
+		t.Error("No stream block should result in no StreamUpstreams")
+	}
+}

--- a/vendor/github.com/nginxinc/nginx-plus-go-sdk/tests/client_test.go
+++ b/vendor/github.com/nginxinc/nginx-plus-go-sdk/tests/client_test.go
@@ -1,0 +1,551 @@
+package tests
+
+import (
+	"net"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/nginxinc/nginx-plus-go-sdk/client"
+)
+
+const (
+	upstream       = "test"
+	streamUpstream = "stream_test"
+)
+
+func TestStreamClient(t *testing.T) {
+	httpClient := &http.Client{}
+	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
+
+	if err != nil {
+		t.Fatalf("Error when creating a client: %v", err)
+	}
+
+	streamServer := client.StreamUpstreamServer{
+		Server: "127.0.0.1:8001",
+	}
+	// test adding a stream server
+
+	err = c.AddStreamServer(streamUpstream, streamServer)
+
+	if err != nil {
+		t.Fatalf("Error when adding a server: %v", err)
+	}
+
+	err = c.AddStreamServer(streamUpstream, streamServer)
+
+	if err == nil {
+		t.Errorf("Adding a duplicated server succeeded")
+	}
+
+	// test deleting a stream server
+
+	err = c.DeleteStreamServer(streamUpstream, streamServer.Server)
+	if err != nil {
+		t.Fatalf("Error when deleting a server: %v", err)
+	}
+
+	err = c.DeleteStreamServer(streamUpstream, streamServer.Server)
+	if err == nil {
+		t.Errorf("Deleting a nonexisting server succeeded")
+	}
+
+	streamServers, err := c.GetStreamServers(streamUpstream)
+	if err != nil {
+		t.Errorf("Error getting stream servers: %v", err)
+	}
+	if len(streamServers) != 0 {
+		t.Errorf("Expected 0 servers, got %v", streamServers)
+	}
+
+	// test updating stream servers
+	streamServers1 := []client.StreamUpstreamServer{
+		client.StreamUpstreamServer{
+			Server: "127.0.0.2:8001",
+		},
+		client.StreamUpstreamServer{
+			Server: "127.0.0.2:8002",
+		},
+		client.StreamUpstreamServer{
+			Server: "127.0.0.2:8003",
+		},
+	}
+
+	streamAdded, streamDeleted, err := c.UpdateStreamServers(streamUpstream, streamServers1)
+
+	if err != nil {
+		t.Fatalf("Error when updating servers: %v", err)
+	}
+	if len(streamAdded) != len(streamServers1) {
+		t.Errorf("The number of added servers %v != %v", len(streamAdded), len(streamServers1))
+	}
+	if len(streamDeleted) != 0 {
+		t.Errorf("The number of deleted servers %v != 0", len(streamDeleted))
+	}
+
+	// test getting servers
+
+	streamServers, err = c.GetStreamServers(streamUpstream)
+	if err != nil {
+		t.Fatalf("Error when getting servers: %v", err)
+	}
+	if !compareStreamUpstreamServers(streamServers1, streamServers) {
+		t.Errorf("Return servers %v != added servers %v", streamServers, streamServers1)
+	}
+
+	// updating with the same servers
+
+	added, deleted, err := c.UpdateStreamServers(streamUpstream, streamServers1)
+
+	if err != nil {
+		t.Fatalf("Error when updating servers: %v", err)
+	}
+	if len(added) != 0 {
+		t.Errorf("The number of added servers %v != 0", len(added))
+	}
+	if len(deleted) != 0 {
+		t.Errorf("The number of deleted servers %v != 0", len(deleted))
+	}
+
+	streamServers2 := []client.StreamUpstreamServer{
+		client.StreamUpstreamServer{
+			Server: "127.0.0.2:8003",
+		},
+		client.StreamUpstreamServer{
+			Server: "127.0.0.2:8004",
+		}, client.StreamUpstreamServer{
+			Server: "127.0.0.2:8005",
+		},
+	}
+
+	// updating with 2 new servers, 1 existing
+
+	added, deleted, err = c.UpdateStreamServers(streamUpstream, streamServers2)
+
+	if err != nil {
+		t.Fatalf("Error when updating servers: %v", err)
+	}
+	if len(added) != 2 {
+		t.Errorf("The number of added servers %v != 2", len(added))
+	}
+	if len(deleted) != 2 {
+		t.Errorf("The number of deleted servers %v != 2", len(deleted))
+	}
+
+	// updating with zero servers - removing
+
+	added, deleted, err = c.UpdateStreamServers(streamUpstream, []client.StreamUpstreamServer{})
+
+	if err != nil {
+		t.Fatalf("Error when updating servers: %v", err)
+	}
+	if len(added) != 0 {
+		t.Errorf("The number of added servers %v != 0", len(added))
+	}
+	if len(deleted) != 3 {
+		t.Errorf("The number of deleted servers %v != 3", len(deleted))
+	}
+
+	// test getting servers again
+
+	servers, err := c.GetStreamServers(streamUpstream)
+	if err != nil {
+		t.Fatalf("Error when getting servers: %v", err)
+	}
+
+	if len(servers) != 0 {
+		t.Errorf("The number of servers %v != 0", len(servers))
+	}
+}
+
+// Test adding the slow_start property on an upstream server
+func TestStreamUpstreamServerSlowStart(t *testing.T) {
+	httpClient := &http.Client{}
+	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
+	if err != nil {
+		t.Fatalf("Error connecting to nginx: %v", err)
+	}
+
+	// Add a server with slow_start
+	// (And FailTimeout, since the default is 10s)
+	streamServer := client.StreamUpstreamServer{
+		Server:      "127.0.0.1:2000",
+		SlowStart:   "11s",
+		FailTimeout: "10s",
+	}
+	err = c.AddStreamServer(streamUpstream, streamServer)
+	if err != nil {
+		t.Errorf("Error adding upstream server: %v", err)
+	}
+	servers, err := c.GetStreamServers(streamUpstream)
+	if err != nil {
+		t.Fatalf("Error getting stream servers: %v", err)
+	}
+	if len(servers) != 1 {
+		t.Errorf("Too many servers")
+	}
+	// don't compare IDs
+	servers[0].ID = 0
+
+	if !reflect.DeepEqual(streamServer, servers[0]) {
+		t.Errorf("Expected: %v Got: %v", streamServer, servers[0])
+	}
+
+	// remove upstream servers
+	_, _, err = c.UpdateStreamServers(streamUpstream, []client.StreamUpstreamServer{})
+	if err != nil {
+		t.Errorf("Couldn't remove servers: %v", err)
+	}
+}
+
+func TestClient(t *testing.T) {
+	httpClient := &http.Client{}
+	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
+
+	if err != nil {
+		t.Fatalf("Error when creating a client: %v", err)
+	}
+
+	// test checking an upstream for exististence
+
+	err = c.CheckIfUpstreamExists(upstream)
+	if err != nil {
+		t.Fatalf("Error when checking an upstream for existence: %v", err)
+	}
+
+	err = c.CheckIfUpstreamExists("random")
+	if err == nil {
+		t.Errorf("Nonexisting upstream exists")
+	}
+
+	server := client.UpstreamServer{
+		Server: "127.0.0.1:8001",
+	}
+
+	// test adding a http server
+
+	err = c.AddHTTPServer(upstream, server)
+
+	if err != nil {
+		t.Fatalf("Error when adding a server: %v", err)
+	}
+
+	err = c.AddHTTPServer(upstream, server)
+
+	if err == nil {
+		t.Errorf("Adding a duplicated server succeeded")
+	}
+
+	// test deleting a http server
+
+	err = c.DeleteHTTPServer(upstream, server.Server)
+	if err != nil {
+		t.Fatalf("Error when deleting a server: %v", err)
+	}
+
+	err = c.DeleteHTTPServer(upstream, server.Server)
+	if err == nil {
+		t.Errorf("Deleting a nonexisting server succeeded")
+	}
+
+	// test updating servers
+	servers1 := []client.UpstreamServer{
+		client.UpstreamServer{
+			Server: "127.0.0.2:8001",
+		},
+		client.UpstreamServer{
+			Server: "127.0.0.2:8002",
+		},
+		client.UpstreamServer{
+			Server: "127.0.0.2:8003",
+		},
+	}
+
+	added, deleted, err := c.UpdateHTTPServers(upstream, servers1)
+
+	if err != nil {
+		t.Fatalf("Error when updating servers: %v", err)
+	}
+	if len(added) != len(servers1) {
+		t.Errorf("The number of added servers %v != %v", len(added), len(servers1))
+	}
+	if len(deleted) != 0 {
+		t.Errorf("The number of deleted servers %v != 0", len(deleted))
+	}
+
+	// test getting servers
+
+	servers, err := c.GetHTTPServers(upstream)
+	if err != nil {
+		t.Fatalf("Error when getting servers: %v", err)
+	}
+	if !compareUpstreamServers(servers1, servers) {
+		t.Errorf("Return servers %v != added servers %v", servers, servers1)
+	}
+
+	// continue test updating servers
+
+	// updating with the same servers
+
+	added, deleted, err = c.UpdateHTTPServers(upstream, servers1)
+
+	if err != nil {
+		t.Fatalf("Error when updating servers: %v", err)
+	}
+	if len(added) != 0 {
+		t.Errorf("The number of added servers %v != 0", len(added))
+	}
+	if len(deleted) != 0 {
+		t.Errorf("The number of deleted servers %v != 0", len(deleted))
+	}
+
+	servers2 := []client.UpstreamServer{
+		client.UpstreamServer{
+			Server: "127.0.0.2:8003",
+		},
+		client.UpstreamServer{
+			Server: "127.0.0.2:8004",
+		}, client.UpstreamServer{
+			Server: "127.0.0.2:8005",
+		},
+	}
+
+	// updating with 2 new servers, 1 existing
+
+	added, deleted, err = c.UpdateHTTPServers(upstream, servers2)
+
+	if err != nil {
+		t.Fatalf("Error when updating servers: %v", err)
+	}
+	if len(added) != 2 {
+		t.Errorf("The number of added servers %v != 2", len(added))
+	}
+	if len(deleted) != 2 {
+		t.Errorf("The number of deleted servers %v != 2", len(deleted))
+	}
+
+	// updating with zero servers - removing
+
+	added, deleted, err = c.UpdateHTTPServers(upstream, []client.UpstreamServer{})
+
+	if err != nil {
+		t.Fatalf("Error when updating servers: %v", err)
+	}
+	if len(added) != 0 {
+		t.Errorf("The number of added servers %v != 0", len(added))
+	}
+	if len(deleted) != 3 {
+		t.Errorf("The number of deleted servers %v != 3", len(deleted))
+	}
+
+	// test getting servers again
+
+	servers, err = c.GetHTTPServers(upstream)
+	if err != nil {
+		t.Fatalf("Error when getting servers: %v", err)
+	}
+
+	if len(servers) != 0 {
+		t.Errorf("The number of servers %v != 0", len(servers))
+	}
+}
+
+// Test adding the slow_start property on an upstream server
+func TestUpstreamServerSlowStart(t *testing.T) {
+	httpClient := &http.Client{}
+	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
+	if err != nil {
+		t.Fatalf("Error connecting to nginx: %v", err)
+	}
+
+	// Add a server with slow_start
+	// (And FailTimeout, since the default is 10s)
+	server := client.UpstreamServer{
+		Server:      "127.0.0.1:2000",
+		SlowStart:   "11s",
+		FailTimeout: "10s",
+	}
+	err = c.AddHTTPServer(upstream, server)
+	if err != nil {
+		t.Errorf("Error adding upstream server: %v", err)
+	}
+	servers, err := c.GetHTTPServers(upstream)
+	if err != nil {
+		t.Fatalf("Error getting HTTPServers: %v", err)
+	}
+	if len(servers) != 1 {
+		t.Errorf("Too many servers")
+	}
+	// don't compare IDs
+	servers[0].ID = 0
+
+	if !reflect.DeepEqual(server, servers[0]) {
+		t.Errorf("Expected: %v Got: %v", server, servers[0])
+	}
+
+	// remove upstream servers
+	_, _, err = c.UpdateHTTPServers(upstream, []client.UpstreamServer{})
+	if err != nil {
+		t.Errorf("Couldn't remove servers: %v", err)
+	}
+}
+
+func TestStats(t *testing.T) {
+	httpClient := &http.Client{}
+	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
+	if err != nil {
+		t.Fatalf("Error connecting to nginx: %v", err)
+	}
+
+	server := client.UpstreamServer{
+		Server: "127.0.0.1:8080",
+	}
+	err = c.AddHTTPServer(upstream, server)
+	if err != nil {
+		t.Errorf("Error adding upstream server: %v", err)
+	}
+
+	stats, err := c.GetStats()
+	if err != nil {
+		t.Errorf("Error getting stats: %v", err)
+	}
+
+	if stats.Connections.Accepted < 1 {
+		t.Errorf("Bad connections: %v", stats.Connections)
+	}
+	if stats.HTTPRequests.Total < 1 {
+		t.Errorf("Bad HTTPRequests: %v", stats.HTTPRequests)
+	}
+	// SSL metrics blank in this example
+	if len(stats.ServerZones) < 1 {
+		t.Errorf("No ServerZone metrics: %v", stats.ServerZones)
+	}
+	if val, ok := stats.ServerZones["test"]; ok {
+		if val.Requests < 1 {
+			t.Errorf("ServerZone stats missing: %v", val)
+		}
+	} else {
+		t.Errorf("ServerZone 'test' not found")
+	}
+	if ups, ok := stats.Upstreams["test"]; ok {
+		if len(ups.Peers) < 1 {
+			t.Errorf("upstream server not visible in stats")
+		} else {
+			if ups.Peers[0].State != "up" {
+				t.Errorf("upstream server state should be 'up'")
+			}
+			if ups.Peers[0].Responses.Total < 0 {
+				t.Errorf("upstream should have total responses value")
+			}
+			if ups.Peers[0].HealthChecks.LastPassed {
+				t.Errorf("upstream server health check should report last failed")
+			}
+		}
+	} else {
+		t.Errorf("Upstream 'test' not found")
+	}
+
+	// cleanup upstream servers
+	_, _, err = c.UpdateHTTPServers(upstream, []client.UpstreamServer{})
+	if err != nil {
+		t.Errorf("Couldn't remove servers: %v", err)
+	}
+}
+
+func TestStreamStats(t *testing.T) {
+	httpClient := &http.Client{}
+	c, err := client.NewNginxClient(httpClient, "http://127.0.0.1:8080/api")
+	if err != nil {
+		t.Fatalf("Error connecting to nginx: %v", err)
+	}
+
+	server := client.StreamUpstreamServer{
+		Server: "127.0.0.1:8080",
+	}
+	err = c.AddStreamServer(streamUpstream, server)
+	if err != nil {
+		t.Errorf("Error adding stream upstream server: %v", err)
+	}
+
+	// make connection so we have stream server zone stats - ignore response
+	_, err = net.Dial("tcp", "127.0.0.1:8081")
+	if err != nil {
+		t.Errorf("Error making tcp connection: %v", err)
+	}
+
+	// wait for health checks
+	time.Sleep(50 * time.Millisecond)
+
+	stats, err := c.GetStats()
+	if err != nil {
+		t.Errorf("Error getting stats: %v", err)
+	}
+
+	if stats.Connections.Active == 0 {
+		t.Errorf("Bad connections: %v", stats.Connections)
+	}
+
+	if len(stats.StreamServerZones) < 1 {
+		t.Errorf("No StreamServerZone metrics: %v", stats.StreamServerZones)
+	}
+
+	if streamServerZone, ok := stats.StreamServerZones[streamUpstream]; ok {
+		if streamServerZone.Connections < 1 {
+			t.Errorf("StreamServerZone stats missing: %v", streamServerZone)
+		}
+	} else {
+		t.Errorf("StreamServerZone 'stream_test' not found")
+	}
+
+	if upstream, ok := stats.StreamUpstreams[streamUpstream]; ok {
+		if len(upstream.Peers) < 1 {
+			t.Errorf("stream upstream server not visible in stats")
+		} else {
+			if upstream.Peers[0].State != "up" {
+				t.Errorf("stream upstream server state should be 'up'")
+			}
+			if upstream.Peers[0].Connections < 1 {
+				t.Errorf("stream upstream should have connects value")
+			}
+			if !upstream.Peers[0].HealthChecks.LastPassed {
+				t.Errorf("stream upstream server health check should report last passed")
+			}
+		}
+	} else {
+		t.Errorf("Stream upstream 'stream_test' not found")
+	}
+
+	// cleanup stream upstream servers
+	_, _, err = c.UpdateStreamServers(streamUpstream, []client.StreamUpstreamServer{})
+	if err != nil {
+		t.Errorf("Couldn't remove stream servers: %v", err)
+	}
+}
+
+func compareUpstreamServers(x []client.UpstreamServer, y []client.UpstreamServer) bool {
+	var xServers []string
+	for _, us := range x {
+		xServers = append(xServers, us.Server)
+	}
+	var yServers []string
+	for _, us := range y {
+		yServers = append(yServers, us.Server)
+	}
+
+	return reflect.DeepEqual(xServers, yServers)
+}
+
+func compareStreamUpstreamServers(x []client.StreamUpstreamServer, y []client.StreamUpstreamServer) bool {
+	var xServers []string
+	for _, us := range x {
+		xServers = append(xServers, us.Server)
+	}
+	var yServers []string
+	for _, us := range y {
+		yServers = append(yServers, us.Server)
+	}
+
+	return reflect.DeepEqual(xServers, yServers)
+}


### PR DESCRIPTION
Adding a stage to build prometheus exporter binaries for the
supported platforms: Linux (i386 and amd64)

### Proposed changes
Travis and make will provide means to build binaries and archive them in tarballs. A sha256 will be generated to confirm package has been downloaded ok
### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/master/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

