### PR TITLE
Add binaries build to Makefile. Add clean target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ PREFIX = nginx-prometheus-exporter
 TAG = $(VERSION)
 GIT_COMMIT = $(shell git rev-parse --short HEAD)
 
+BUILD_DIR = build_output
+
+nginx-prometheus-exporter: test
+	CGO_ENABLED=0 go build -installsuffix cgo -ldflags "-X main.version=$(VERSION) -X main.gitCommit=$(GIT_COMMIT)" -o nginx-prometheus-exporter 
+
 test:
 	go test ./...
 
@@ -11,3 +16,28 @@ container:
 
 push: container
 	docker push $(PREFIX):$(TAG)
+
+$(BUILD_DIR)/nginx-prometheus-exporter-linux-amd64:
+	GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -ldflags "-X main.version=$(VERSION) -X main.gitCommit=$(GIT_COMMIT)" -o $(BUILD_DIR)/nginx-prometheus-exporter-linux-amd64
+
+$(BUILD_DIR)/nginx-prometheus-exporter-linux-i386:
+	GOARCH=386 CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -ldflags "-X main.version=$(VERSION) -X main.gitCommit=$(GIT_COMMIT)" -o $(BUILD_DIR)/nginx-prometheus-exporter-linux-i386
+
+release: $(BUILD_DIR)/nginx-prometheus-exporter-linux-amd64 $(BUILD_DIR)/nginx-prometheus-exporter-linux-i386
+	mv $(BUILD_DIR)/nginx-prometheus-exporter-linux-amd64 $(BUILD_DIR)/nginx-prometheus-exporter && \
+	tar czf $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-amd64.tar.gz -C $(BUILD_DIR) nginx-prometheus-exporter && \
+	rm $(BUILD_DIR)/nginx-prometheus-exporter
+
+	mv $(BUILD_DIR)/nginx-prometheus-exporter-linux-i386 $(BUILD_DIR)/nginx-prometheus-exporter && \
+	tar czf $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-i386.tar.gz -C $(BUILD_DIR) nginx-prometheus-exporter && \
+	rm $(BUILD_DIR)/nginx-prometheus-exporter
+    
+	shasum -a 256 $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-amd64.tar.gz $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-i386.tar.gz|sed "s|$(BUILD_DIR)/||" > $(BUILD_DIR)/sha256sums.txt
+
+clean:
+	-rm $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-amd64.tar.gz
+	-rm $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-i386.tar.gz
+	-rm $(BUILD_DIR)/sha256sums.txt
+	-rmdir $(BUILD_DIR)
+	-rm nginx-prometheus-exporter
+


### PR DESCRIPTION
Adding a stage to build prometheus exporter binaries for the
supported platforms: Linux (i386 and amd64)

### Proposed changes
Makefile has now targes to build binaries for i386 and amd64 (linux).
Cleanup and build binary of local system targets added too.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/master/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

