### PR TITLE
Implement up metrics and timeout cli argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,11 @@ Usage of ./nginx-prometheus-exporter:
 
 ### Exported Metrics
 
-* For NGINX, all stub_status metrics are exported. Connect to the `/metrics` page of the running exporter to see the complete list of metrics along with their descriptions.
+* For NGINX, the following metrics are exported:
+    * All [stub_status](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html) metrics.
+    * `nginx_up` -- shows the status of the last metric scrape: `1` for a successful scrape and `0` for a failed one.
+    
+    Connect to the `/metrics` page of the running exporter to see the complete list of metrics along with their descriptions.
 * For NGINX Plus, the following metrics are exported:
     * [Connections](http://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_connections).
     * [HTTP](http://nginx.org/en/docs/http/ngx_http_api_module.html#http_).
@@ -86,6 +90,7 @@ Usage of ./nginx-prometheus-exporter:
     * [Stream Server Zones](http://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_stream_server_zone).
     * [HTTP Upstreams](http://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_http_upstream). Note: for the `state` metric, the string values are converted to float64 using the following rule: `"up"` -> `1.0`, `"draining"` -> `2.0`, `"down"` -> `3.0`, `"unavail"` –> `4.0`, `"checking"` –> `5.0`, `"unhealthy"` -> `6.0`.
     * [Stream Upstreams](http://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_stream_upstream). Note: for the `state` metric, the string values are converted to float64 using the following rule: `"up"` -> `1.0`, `"down"` -> `3.0`, `"unavail"` –> `4.0`, `"checking"` –> `5.0`, `"unhealthy"` -> `6.0`.
+    * `nginxplus_up` -- shows the status of the last metric scrape: `1` for a successful scrape and `0` for a failed one.
 
 
     Connect to the `/metrics` page of the running exporter to see the complete list of metrics along with their descriptions. Note: to see server zones related metrics you must configure [status zones](https://nginx.org/en/docs/http/ngx_http_status_module.html#status_zone) and to see upstream related metrics you must configure upstreams with a [shared memory zone](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#zone).

--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ Usage of ./nginx-prometheus-exporter:
         A URI for scraping NGINX or NGINX Plus metrics.
         For NGINX, the stub_status page must be available through the URI. For NGINX Plus -- the API. The default value can be overwritten by SCRAPE_URI environment variable. (default "http://127.0.0.1:8080/stub_status")
   -nginx.ssl-verify
-        Perform SSL certificate verification. The default value can be overwritten by SSL_VERIFY environment variable.
+        Perform SSL certificate verification. The default value can be overwritten by SSL_VERIFY environment variable. (default true)
+  -nginx.timeout duration
+        A timeout for scraping metrics from NGINX or NGINX Plus. (default 5s)
   -web.listen-address string
         An address to listen on for web interface and telemetry. The default value can be overwritten by LISTEN_ADDRESS environment variable. (default ":9113")
   -web.telemetry-path string

--- a/collector/helper.go
+++ b/collector/helper.go
@@ -2,6 +2,17 @@ package collector
 
 import "github.com/prometheus/client_golang/prometheus"
 
+const nginxUp = 1
+const nginxDown = 0
+
 func newGlobalMetric(namespace string, metricName string, docString string) *prometheus.Desc {
 	return prometheus.NewDesc(namespace+"_"+metricName, docString, nil, nil)
+}
+
+func newUpMetric(namespace string) prometheus.Gauge {
+	return prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "up",
+		Help:      "Status of the last metric scrape",
+	})
 }


### PR DESCRIPTION
### Proposed changes
- Implements https://github.com/nginxinc/nginx-prometheus-exporter/issues/26 - nginx_up and nginxplus_up metrics.
- Adds -nginx.timeout cli argument for setting a timeout for scrapping metrics from NGINX or NGINX Plus.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/master/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

