### PR TITLE
Retry connection if NGINX unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,16 @@ Usage of ./nginx-prometheus-exporter:
   -nginx.plus
         Start the exporter for NGINX Plus. By default, the exporter is started for NGINX. The default value can be overwritten by NGINX_PLUS environment variable.
   -nginx.retries int
-        A number of retries the exporter will make on start to connect to the NGINX stub_status page/NGINX Plus API before exiting with an error.
+        A number of retries the exporter will make on start to connect to the NGINX stub_status page/NGINX Plus API before exiting with an error. The default value can be overwritten by NGINX_RETRIES environment variable.
   -nginx.retry-interval duration
-        An interval between retries to connect to the NGINX stub_status page/NGINX Plus API on start. (default 5s)
+        An interval between retries to connect to the NGINX stub_status page/NGINX Plus API on start. The default value can be overwritten by NGINX_RETRY_INTERVAL environment variable. (default 5s)
   -nginx.scrape-uri string
         A URI for scraping NGINX or NGINX Plus metrics.
         For NGINX, the stub_status page must be available through the URI. For NGINX Plus -- the API. The default value can be overwritten by SCRAPE_URI environment variable. (default "http://127.0.0.1:8080/stub_status")
   -nginx.ssl-verify
         Perform SSL certificate verification. The default value can be overwritten by SSL_VERIFY environment variable. (default true)
   -nginx.timeout duration
-        A timeout for scraping metrics from NGINX or NGINX Plus. (default 5s)
+        A timeout for scraping metrics from NGINX or NGINX Plus. The default value can be overwritten by TIMEOUT environment variable. (default 5s)
   -web.listen-address string
         An address to listen on for web interface and telemetry. The default value can be overwritten by LISTEN_ADDRESS environment variable. (default ":9113")
   -web.telemetry-path string

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ To start the exporter we use the [docker run](https://docs.docker.com/engine/ref
 Usage of ./nginx-prometheus-exporter:
   -nginx.plus
         Start the exporter for NGINX Plus. By default, the exporter is started for NGINX. The default value can be overwritten by NGINX_PLUS environment variable.
+  -nginx.retries int
+        A number of retries the exporter will make on start to connect to the NGINX stub_status page/NGINX Plus API before exiting with an error.
+  -nginx.retry-interval duration
+        An interval between retries to connect to the NGINX stub_status page/NGINX Plus API on start. (default 5s)
   -nginx.scrape-uri string
         A URI for scraping NGINX or NGINX Plus metrics.
         For NGINX, the stub_status page must be available through the URI. For NGINX Plus -- the API. The default value can be overwritten by SCRAPE_URI environment variable. (default "http://127.0.0.1:8080/stub_status")
@@ -84,7 +88,7 @@ Usage of ./nginx-prometheus-exporter:
 * For NGINX, the following metrics are exported:
     * All [stub_status](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html) metrics.
     * `nginx_up` -- shows the status of the last metric scrape: `1` for a successful scrape and `0` for a failed one.
-    
+
     Connect to the `/metrics` page of the running exporter to see the complete list of metrics along with their descriptions.
 * For NGINX Plus, the following metrics are exported:
     * [Connections](http://nginx.org/en/docs/http/ngx_http_api_module.html#def_nginx_connections).

--- a/client/nginx.go
+++ b/client/nginx.go
@@ -37,11 +37,8 @@ func NewNginxClient(httpClient *http.Client, apiEndpoint string) (*NginxClient, 
 		httpClient:  httpClient,
 	}
 
-	if _, err := client.GetStubStats(); err != nil {
-		return nil, err
-	}
-
-	return client, nil
+	_, err := client.GetStubStats()
+	return client, err
 }
 
 // GetStubStats fetches the stub_status metrics.

--- a/client/nginx.go
+++ b/client/nginx.go
@@ -38,7 +38,7 @@ func NewNginxClient(httpClient *http.Client, apiEndpoint string) (*NginxClient, 
 	}
 
 	if _, err := client.GetStubStats(); err != nil {
-		return nil, fmt.Errorf("Failed to create NginxClient: %v", err)
+		return nil, err
 	}
 
 	return client, nil

--- a/exporter.go
+++ b/exporter.go
@@ -111,13 +111,13 @@ var (
 		"Perform SSL certificate verification. The default value can be overwritten by SSL_VERIFY environment variable.")
 	timeout = flag.Duration("nginx.timeout",
 		defaultTimeout,
-		"A timeout for scraping metrics from NGINX or NGINX Plus.")
+		"A timeout for scraping metrics from NGINX or NGINX Plus. The default value can be overwritten by TIMEOUT environment variable.")
 	nginxRetries = flag.Int("nginx.retries",
 		defaultNginxRetries,
-		"A number of retries the exporter will make on start to connect to the NGINX stub_status page/NGINX Plus API before exiting with an error.")
+		"A number of retries the exporter will make on start to connect to the NGINX stub_status page/NGINX Plus API before exiting with an error. The default value can be overwritten by NGINX_RETRIES environment variable.")
 	nginxRetryInterval = flag.Duration("nginx.retry-interval",
 		defaultNginxRetryInterval,
-		"An interval between retries to connect to the NGINX stub_status page/NGINX Plus API on start.")
+		"An interval between retries to connect to the NGINX stub_status page/NGINX Plus API on start. The default value can be overwritten by NGINX_RETRY_INTERVAL environment variable.")
 )
 
 func main() {

--- a/exporter.go
+++ b/exporter.go
@@ -65,13 +65,15 @@ func getEnvDuration(key string, defaultValue time.Duration) time.Duration {
 func createClientWithRetries(getClient func() (interface{}, error), retries int, retryInterval time.Duration) (interface{}, error) {
 	var err error
 	var nginxClient interface{}
-	for retryNum := retries; retryNum >= 0; retryNum-- {
+
+	for i := retries; i >= 0; i-- {
 		nginxClient, err = getClient()
-		if err != nil && retryNum > 0 {
+		if err == nil {
+			return nginxClient, nil
+		}
+		if i > 0 {
 			log.Printf("Could not create Nginx Client. Retrying in %v...", retryInterval)
 			time.Sleep(retryInterval)
-		} else if err == nil {
-			return nginxClient, nil
 		}
 	}
 	return nil, err
@@ -182,6 +184,6 @@ func main() {
 			</body>
 			</html>`))
 	})
-	log.Printf("NGINX Prometheus Exporter has successfully started. Metrics available at http://localhost%v%v", *listenAddr, *metricsPath)
+	log.Printf("NGINX Prometheus Exporter has successfully started")
 	log.Fatal(http.ListenAndServe(*listenAddr, nil))
 }

--- a/exporter.go
+++ b/exporter.go
@@ -31,11 +31,11 @@ func getEnvInt(key string, defaultValue int) int {
 	if !ok {
 		return defaultValue
 	}
-	b, err := strconv.ParseInt(value, 10, 64)
+	i, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
-		log.Fatalf("Environment variable value for %s must be an int", key)
+		log.Fatalf("Environment variable value for %s must be an int: %v", key, err)
 	}
-	return int(b)
+	return int(i)
 }
 
 func getEnvBool(key string, defaultValue bool) bool {
@@ -45,9 +45,21 @@ func getEnvBool(key string, defaultValue bool) bool {
 	}
 	b, err := strconv.ParseBool(value)
 	if err != nil {
-		log.Fatalf("Environment variable value for %s must be a boolean", key)
+		log.Fatalf("Environment variable value for %s must be a boolean: %v", key, err)
 	}
 	return b
+}
+
+func getEnvDuration(key string, defaultValue time.Duration) time.Duration {
+	value, ok := os.LookupEnv(key)
+	if !ok {
+		return defaultValue
+	}
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		log.Fatalf("Environment variable value for %s must be a duration: %v", key, err)
+	}
+	return d
 }
 
 func createClientWithRetries(httpClient http.Client, scrapeURI, clientName string, nginxPlus bool, retries int, retryInterval time.Duration) (interface{}, error) {
@@ -79,29 +91,41 @@ var (
 	gitCommit string
 
 	// Defaults values
-	defaultListenAddress = getEnv("LISTEN_ADDRESS", ":9113")
-	defaultMetricsPath   = getEnv("TELEMETRY_PATH", "/metrics")
-	defaultNginxPlus     = getEnvBool("NGINX_PLUS", false)
-	defaultScrapeURI     = getEnv("SCRAPE_URI", "http://127.0.0.1:8080/stub_status")
-	defaultSslVerify     = getEnvBool("SSL_VERIFY", true)
-	defaultNginxRetries  = getEnvInt("NGINX_RETRIES", 0)
+	defaultListenAddress      = getEnv("LISTEN_ADDRESS", ":9113")
+	defaultMetricsPath        = getEnv("TELEMETRY_PATH", "/metrics")
+	defaultNginxPlus          = getEnvBool("NGINX_PLUS", false)
+	defaultScrapeURI          = getEnv("SCRAPE_URI", "http://127.0.0.1:8080/stub_status")
+	defaultSslVerify          = getEnvBool("SSL_VERIFY", true)
+	defaultTimeout            = getEnvDuration("TIMEOUT", time.Second*5)
+	defaultNginxRetries       = getEnvInt("NGINX_RETRIES", 0)
+	defaultNginxRetryInterval = getEnvDuration("NGINX_RETRY_INTERVAL", time.Second*5)
 
 	// Command-line flags
-	listenAddr = flag.String("web.listen-address", defaultListenAddress,
+	listenAddr = flag.String("web.listen-address",
+		defaultListenAddress,
 		"An address to listen on for web interface and telemetry. The default value can be overwritten by LISTEN_ADDRESS environment variable.")
-	metricsPath = flag.String("web.telemetry-path", defaultMetricsPath,
+	metricsPath = flag.String("web.telemetry-path",
+		defaultMetricsPath,
 		"A path under which to expose metrics. The default value can be overwritten by TELEMETRY_PATH environment variable.")
-	nginxPlus = flag.Bool("nginx.plus", defaultNginxPlus,
+	nginxPlus = flag.Bool("nginx.plus",
+		defaultNginxPlus,
 		"Start the exporter for NGINX Plus. By default, the exporter is started for NGINX. The default value can be overwritten by NGINX_PLUS environment variable.")
-	scrapeURI = flag.String("nginx.scrape-uri", defaultScrapeURI,
+	scrapeURI = flag.String("nginx.scrape-uri",
+		defaultScrapeURI,
 		`A URI for scraping NGINX or NGINX Plus metrics.
 	For NGINX, the stub_status page must be available through the URI. For NGINX Plus -- the API. The default value can be overwritten by SCRAPE_URI environment variable.`)
-	sslVerify = flag.Bool("nginx.ssl-verify", defaultSslVerify,
+	sslVerify = flag.Bool("nginx.ssl-verify",
+		defaultSslVerify,
 		"Perform SSL certificate verification. The default value can be overwritten by SSL_VERIFY environment variable.")
-	timeout      = flag.Duration("nginx.timeout", 5*time.Second, "A timeout for scraping metrics from NGINX or NGINX Plus.")
-	nginxRetries = flag.Int("nginx.retries", defaultNginxRetries,
+	timeout = flag.Duration("nginx.timeout",
+		defaultTimeout,
+		"A timeout for scraping metrics from NGINX or NGINX Plus.")
+	nginxRetries = flag.Int("nginx.retries",
+		defaultNginxRetries,
 		"A number of retries the exporter will make on start to connect to the NGINX stub_status page/NGINX Plus API before exiting with an error.")
-	nginxRetryInterval = flag.Duration("nginx.retry-interval", 5*time.Second, "An interval between retries to connect to the NGINX stub_status page/NGINX Plus API on start.")
+	nginxRetryInterval = flag.Duration("nginx.retry-interval",
+		defaultNginxRetryInterval,
+		"An interval between retries to connect to the NGINX stub_status page/NGINX Plus API on start.")
 )
 
 func main() {
@@ -152,7 +176,6 @@ func main() {
 		}
 		registry.MustRegister(collector.NewNginxCollector(ossClient.(*client.NginxClient), "nginx"))
 	}
-
 	http.Handle(*metricsPath, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>
@@ -163,6 +186,6 @@ func main() {
 			</body>
 			</html>`))
 	})
-	log.Printf("NGINX Prometheus Exporter has successfully started")
+	log.Printf("NGINX Prometheus Exporter has successfully started. Metrics available at http://localhost%v%v", *listenAddr, *metricsPath)
 	log.Fatal(http.ListenAndServe(*listenAddr, nil))
 }

--- a/exporter.go
+++ b/exporter.go
@@ -6,7 +6,9 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 
 	plusclient "github.com/nginxinc/nginx-plus-go-sdk/client"
@@ -106,6 +108,13 @@ func main() {
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: !*sslVerify},
 		},
 	}
+
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGTERM)
+	go func() {
+		log.Printf("SIGTERM received: %v. Exiting...", <-signalChan)
+		os.Exit(0)
+	}()
 
 	if *nginxPlus {
 		for {

--- a/exporter.go
+++ b/exporter.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"flag"
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -65,8 +64,9 @@ func getEnvDuration(key string, defaultValue time.Duration) time.Duration {
 
 func createClientWithRetries(getClient func() (interface{}, error), retries int, retryInterval time.Duration) (interface{}, error) {
 	var err error
+	var nginxClient interface{}
 	for retryNum := retries; retryNum >= 0; retryNum-- {
-		nginxClient, err := getClient()
+		nginxClient, err = getClient()
 		if err != nil && retryNum > 0 {
 			log.Printf("Could not create Nginx Client. Retrying in %v...", retryInterval)
 			time.Sleep(retryInterval)
@@ -74,7 +74,7 @@ func createClientWithRetries(getClient func() (interface{}, error), retries int,
 			return nginxClient, nil
 		}
 	}
-	return nil, fmt.Errorf("Could not create Nginx Client: %v", err)
+	return nil, err
 }
 
 var (

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -11,94 +11,62 @@ import (
 )
 
 func TestCreateClientWithRetries(t *testing.T) {
-	type MockedNginxClient struct {
-		apiEndpoint string
-		httpClient  *http.Client
-	}
 	type args struct {
-		httpClient    *http.Client
 		scrapeURI     string
-		clientName    string
 		nginxPlus     bool
 		retries       int
 		retryInterval time.Duration
 	}
-
-	httpClient := &http.Client{}
-
 	tests := []struct {
 		name    string
 		args    args
-		want    MockedNginxClient
 		wantErr bool
 	}{
 		{
 			"Nginx Client, valid uri",
 			args{
-				httpClient: httpClient,
-				clientName: "Nginx Client",
-				scrapeURI:  "http://demo.nginx.com/stub_status",
-				nginxPlus:  false,
-			},
-			MockedNginxClient{
-				apiEndpoint: "http://demo.nginx.com/stub_status",
-				httpClient:  httpClient,
+				scrapeURI: "http://demo.nginx.com/stub_status",
+				nginxPlus: false,
 			},
 			false,
 		},
 		{
 			"Nginx Plus Client, valid uri",
 			args{
-				httpClient: httpClient,
-				clientName: "Nginx Plus Client",
-				scrapeURI:  "http://demo.nginx.com/api",
-				nginxPlus:  true,
-			},
-			MockedNginxClient{
-				apiEndpoint: "http://demo.nginx.com/api",
-				httpClient:  httpClient,
+				scrapeURI: "http://demo.nginx.com/api",
+				nginxPlus: true,
 			},
 			false,
 		},
 		{
 			"Nginx Client, invalid uri",
 			args{
-				httpClient: httpClient,
-				clientName: "Nginx Client",
-				scrapeURI:  "http://TYPOdemo.nginx.com/stub_status",
-				nginxPlus:  false,
-			},
-			MockedNginxClient{
-				apiEndpoint: "http://TYPOdemo.nginx.com/stub_status",
-				httpClient:  httpClient,
+				scrapeURI: "http://TYPO.nginx.com/stub_status",
+				nginxPlus: false,
 			},
 			true,
 		},
 		{
-			"Nginx Client, invalid uri, retries",
+			"Nginx Plus Client, invalid uri, retries",
 			args{
-				httpClient:    httpClient,
-				clientName:    "Nginx Client",
-				scrapeURI:     "http://TYPOdemo.nginx.com/stub_status",
-				nginxPlus:     false,
+				scrapeURI:     "http://TYPO.nginx.com/api",
+				nginxPlus:     true,
 				retries:       2,
-				retryInterval: 1 * time.Second,
-			},
-			MockedNginxClient{
-				apiEndpoint: "http://TYPOdemo.nginx.com/stub_status",
-				httpClient:  httpClient,
+				retryInterval: 100 * time.Millisecond,
 			},
 			true,
 		},
 	}
+
+	httpClient := &http.Client{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := createClientWithRetries(*tt.args.httpClient, tt.args.scrapeURI, tt.args.clientName, tt.args.nginxPlus, tt.args.retries, tt.args.retryInterval)
+			got, err := createClientWithRetries(*httpClient, tt.args.scrapeURI, "clientname", tt.args.nginxPlus, tt.args.retries, tt.args.retryInterval)
 			log.Printf("Error %v, Expected %v", err, tt.wantErr)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createClientWithRetries() error = %v, wantErr %v", err, tt.wantErr)
 			} else if err != nil && tt.wantErr {
-				return // error returned as wanted
+				return
 			}
 
 			if tt.args.nginxPlus {

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -60,8 +59,7 @@ func TestCreateClientWithRetries(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			invocations := 0
 			getClient := func() (interface{}, error) {
-				invocations = invocations + 1
-				fmt.Printf("invocations = %v\n", invocations)
+				invocations++
 				return tt.args.client, tt.args.err
 			}
 

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -23,7 +23,7 @@ func TestCreateClientWithRetries(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			"Valid func",
+			"createClientWithRetries: Valid func",
 			args{
 				getData: func() (interface{}, error) { return "soup", nil },
 			},
@@ -31,7 +31,7 @@ func TestCreateClientWithRetries(t *testing.T) {
 			false,
 		},
 		{
-			"Inavlid func",
+			"createClientWithRetries: Invalid func",
 			args{
 				getData: func() (interface{}, error) { return httpClient.Get("http://FAKE.notarealwebsite.com") },
 			},
@@ -39,7 +39,7 @@ func TestCreateClientWithRetries(t *testing.T) {
 			true,
 		},
 		{
-			"Invalid func with retries",
+			"createClientWithRetries: Invalid func with retries",
 			args{
 				getData:       func() (interface{}, error) { return httpClient.Get("http://FAKE.notarealwebsite.com") },
 				retries:       3,

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"testing"
+	"time"
+
+	plusclient "github.com/nginxinc/nginx-plus-go-sdk/client"
+	"github.com/nginxinc/nginx-prometheus-exporter/client"
+)
+
+func TestCreateClientWithRetries(t *testing.T) {
+	type MockedNginxClient struct {
+		apiEndpoint string
+		httpClient  *http.Client
+	}
+	type args struct {
+		httpClient    *http.Client
+		scrapeURI     string
+		clientName    string
+		nginxPlus     bool
+		retries       int
+		retryInterval time.Duration
+	}
+
+	httpClient := &http.Client{}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    MockedNginxClient
+		wantErr bool
+	}{
+		{
+			"Nginx Client, valid uri",
+			args{
+				httpClient: httpClient,
+				clientName: "Nginx Client",
+				scrapeURI:  "http://demo.nginx.com/stub_status",
+				nginxPlus:  false,
+			},
+			MockedNginxClient{
+				apiEndpoint: "http://demo.nginx.com/stub_status",
+				httpClient:  httpClient,
+			},
+			false,
+		},
+		{
+			"Nginx Plus Client, valid uri",
+			args{
+				httpClient: httpClient,
+				clientName: "Nginx Plus Client",
+				scrapeURI:  "http://demo.nginx.com/api",
+				nginxPlus:  true,
+			},
+			MockedNginxClient{
+				apiEndpoint: "http://demo.nginx.com/api",
+				httpClient:  httpClient,
+			},
+			false,
+		},
+		{
+			"Nginx Client, invalid uri",
+			args{
+				httpClient: httpClient,
+				clientName: "Nginx Client",
+				scrapeURI:  "http://TYPOdemo.nginx.com/stub_status",
+				nginxPlus:  false,
+			},
+			MockedNginxClient{
+				apiEndpoint: "http://TYPOdemo.nginx.com/stub_status",
+				httpClient:  httpClient,
+			},
+			true,
+		},
+		{
+			"Nginx Client, invalid uri, retries",
+			args{
+				httpClient:    httpClient,
+				clientName:    "Nginx Client",
+				scrapeURI:     "http://TYPOdemo.nginx.com/stub_status",
+				nginxPlus:     false,
+				retries:       2,
+				retryInterval: 1 * time.Second,
+			},
+			MockedNginxClient{
+				apiEndpoint: "http://TYPOdemo.nginx.com/stub_status",
+				httpClient:  httpClient,
+			},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := createClientWithRetries(*tt.args.httpClient, tt.args.scrapeURI, tt.args.clientName, tt.args.nginxPlus, tt.args.retries, tt.args.retryInterval)
+			log.Printf("Error %v, Expected %v", err, tt.wantErr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("createClientWithRetries() error = %v, wantErr %v", err, tt.wantErr)
+			} else if err != nil && tt.wantErr {
+				return // error returned as wanted
+			}
+
+			if tt.args.nginxPlus {
+				cl := got.(*plusclient.NginxClient)
+				if _, err := cl.GetStats(); err != nil {
+					t.Errorf("Failed to create NginxPlusClient: %v", err)
+				}
+			} else {
+				cl := got.(*client.NginxClient)
+				if _, err := cl.GetStubStats(); err != nil {
+					t.Errorf("Failed to create NginxClient: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes: https://github.com/nginxinc/nginx-prometheus-exporter/issues/36

### Proposed changes
The exporter will now retry to connect to NGINX if it is unreachable, and `nginx.retries` is set. It will retry a number of times which is set via the new `nginx.retries` cli arg or `NGINX_RETRIES` shell variable.
* Add `nginx.retries` and `nginx.retry-interval` cli args
* Add `NGINX_RETRIES`, `NGINX_RETRY_INTERVAL` and `TIMEOUT` shell variables
* Add NGINX Prometheus Exporter started log. - This lets you know that a retry has succeeded. 
* Add SIGTERM signal handler. - This causes the exporter to exit gracefully once a SIGTERM is received.
* Update README with new cli args/shell variables
* Add unit test for creating a Nginx/Nginx Plus client

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/master/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

