### PR TITLE
Fix nginxRetries accepts a negative value

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"flag"
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -63,11 +62,11 @@ func getEnvDuration(key string, defaultValue time.Duration) time.Duration {
 	return d
 }
 
-func createClientWithRetries(getClient func() (interface{}, error), retries int, retryInterval time.Duration) (interface{}, error) {
-	err := fmt.Errorf(`invalid value "%v" for flag -nginx.retries`, retries)
+func createClientWithRetries(getClient func() (interface{}, error), retries uint, retryInterval time.Duration) (interface{}, error) {
+	var err error
 	var nginxClient interface{}
 
-	for i := retries; i >= 0; i-- {
+	for i := 0; i <= int(retries); i++ {
 		nginxClient, err = getClient()
 		if err == nil {
 			return nginxClient, nil
@@ -92,7 +91,7 @@ var (
 	defaultScrapeURI          = getEnv("SCRAPE_URI", "http://127.0.0.1:8080/stub_status")
 	defaultSslVerify          = getEnvBool("SSL_VERIFY", true)
 	defaultTimeout            = getEnvDuration("TIMEOUT", time.Second*5)
-	defaultNginxRetries       = getEnvInt("NGINX_RETRIES", 0)
+	defaultNginxRetries       = uint(getEnvInt("NGINX_RETRIES", 0))
 	defaultNginxRetryInterval = getEnvDuration("NGINX_RETRY_INTERVAL", time.Second*5)
 
 	// Command-line flags
@@ -115,7 +114,7 @@ var (
 	timeout = flag.Duration("nginx.timeout",
 		defaultTimeout,
 		"A timeout for scraping metrics from NGINX or NGINX Plus. The default value can be overwritten by TIMEOUT environment variable.")
-	nginxRetries = flag.Int("nginx.retries",
+	nginxRetries = flag.Uint("nginx.retries",
 		defaultNginxRetries,
 		"A number of retries the exporter will make on start to connect to the NGINX stub_status page/NGINX Plus API before exiting with an error. The default value can be overwritten by NGINX_RETRIES environment variable.")
 	nginxRetryInterval = flag.Duration("nginx.retry-interval",

--- a/exporter.go
+++ b/exporter.go
@@ -88,10 +88,9 @@ func parsePositiveDuration(s string) (positiveDuration, error) {
 	return positiveDuration{dur}, nil
 }
 
-func createPositiveDurationFlag(dur time.Duration, key, helper string) *positiveDuration {
-	pd := &positiveDuration{dur}
-	flag.Var(pd, key, helper)
-	return pd
+func createPositiveDurationFlag(name string, value positiveDuration, usage string) *positiveDuration {
+	flag.Var(&value, name, usage)
+	return &value
 }
 
 func createClientWithRetries(getClient func() (interface{}, error), retries uint, retryInterval time.Duration) (interface{}, error) {
@@ -148,17 +147,16 @@ var (
 		"A number of retries the exporter will make on start to connect to the NGINX stub_status page/NGINX Plus API before exiting with an error. The default value can be overwritten by NGINX_RETRIES environment variable.")
 
 	// Custom command-line flags
-	timeout = createPositiveDurationFlag(defaultTimeout.Duration,
-		"nginx.timeout",
+	timeout = createPositiveDurationFlag("nginx.timeout",
+		defaultTimeout,
 		"A timeout for scraping metrics from NGINX or NGINX Plus. The default value can be overwritten by TIMEOUT environment variable.")
 
-	nginxRetryInterval = createPositiveDurationFlag(defaultNginxRetryInterval.Duration,
-		"nginx.retry-interval",
+	nginxRetryInterval = createPositiveDurationFlag("nginx.retry-interval",
+		defaultNginxRetryInterval,
 		"An interval between retries to connect to the NGINX stub_status page/NGINX Plus API on start. The default value can be overwritten by NGINX_RETRY_INTERVAL environment variable.")
 )
 
 func main() {
-
 	flag.Parse()
 
 	log.Printf("Starting NGINX Prometheus Exporter Version=%v GitCommit=%v", version, gitCommit)

--- a/exporter.go
+++ b/exporter.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/tls"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -63,7 +64,7 @@ func getEnvDuration(key string, defaultValue time.Duration) time.Duration {
 }
 
 func createClientWithRetries(getClient func() (interface{}, error), retries int, retryInterval time.Duration) (interface{}, error) {
-	var err error
+	err := fmt.Errorf(`invalid value "%v" for flag -nginx.retries`, retries)
 	var nginxClient interface{}
 
 	for i := retries; i >= 0; i-- {

--- a/exporter.go
+++ b/exporter.go
@@ -84,10 +84,10 @@ func (pd *positiveDuration) Set(s string) error {
 	return nil
 }
 
-func createPositiveDurationFlag(dur *time.Duration, key, helper string) (*positiveDuration, error) {
+func createPositiveDurationFlag(dur *time.Duration, key, helper string) *positiveDuration {
 	pd := &positiveDuration{*dur}
 	flag.Var(pd, key, helper)
-	return pd, nil
+	return pd
 }
 
 func createClientWithRetries(getClient func() (interface{}, error), retries uint, retryInterval *time.Duration) (interface{}, error) {
@@ -142,22 +142,18 @@ var (
 	nginxRetries = flag.Uint("nginx.retries",
 		defaultNginxRetries,
 		"A number of retries the exporter will make on start to connect to the NGINX stub_status page/NGINX Plus API before exiting with an error. The default value can be overwritten by NGINX_RETRIES environment variable.")
+
+	// Custom command-line flags
+	timeout = createPositiveDurationFlag(&defaultTimeout.Duration,
+		"nginx.timeout",
+		"A timeout for scraping metrics from NGINX or NGINX Plus. The default value can be overwritten by TIMEOUT environment variable.")
+
+	nginxRetryInterval = createPositiveDurationFlag(&defaultNginxRetryInterval.Duration,
+		"nginx.retry-interval",
+		"An interval between retries to connect to the NGINX stub_status page/NGINX Plus API on start. The default value can be overwritten by NGINX_RETRY_INTERVAL environment variable.")
 )
 
 func main() {
-	timeout, err := createPositiveDurationFlag(&defaultTimeout.Duration,
-		"nginx.timeout",
-		"A timeout for scraping metrics from NGINX or NGINX Plus. The default value can be overwritten by TIMEOUT environment variable.")
-	if err != nil {
-		log.Fatalf("Could not create duration flag timeout=%v: %v", timeout, err)
-	}
-
-	nginxRetryInterval, err := createPositiveDurationFlag(&defaultNginxRetryInterval.Duration,
-		"nginx.retry-interval",
-		"An interval between retries to connect to the NGINX stub_status page/NGINX Plus API on start. The default value can be overwritten by NGINX_RETRY_INTERVAL environment variable.")
-	if err != nil {
-		log.Fatalf("Could not create duration flag nginx.retry-interval=%v: %v", nginxRetryInterval, err)
-	}
 
 	flag.Parse()
 

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -81,3 +81,26 @@ func TestCreateClientWithRetries(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateFlags(t *testing.T) {
+	type args struct {
+		timeout       time.Duration
+		retryInterval time.Duration
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"valid flags", args{5 * time.Second, 5 * time.Second}, false},
+		{"invalid nginxRetries flag input", args{-5 * time.Second, 5 * time.Second}, true},
+		{"invalid nginxRetryInterval flag input", args{5 * time.Second, -5 * time.Second}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateFlags(tt.args.timeout, tt.args.retryInterval); (err != nil) != tt.wantErr {
+				t.Errorf("validateFlags() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -83,43 +83,34 @@ func TestCreateClientWithRetries(t *testing.T) {
 }
 
 func TestParsePositiveDuration(t *testing.T) {
-	type args struct {
-		s string
-	}
 	tests := []struct {
-		name    string
-		args    args
-		want    positiveDuration
-		wantErr bool
+		name      string
+		testInput string
+		want      positiveDuration
+		wantErr   bool
 	}{
 		{
-			"PositiveDurationSet updates flag.Value",
-			args{
-				"15ms",
-			},
+			"ParsePositiveDuration returns a positiveDuration",
+			"15ms",
 			positiveDuration{15 * time.Millisecond},
 			false,
 		},
 		{
-			"PositiveDurationSet returns error for trying to parse negative value",
-			args{
-				"-15ms",
-			},
+			"ParsePositiveDuration returns error for trying to parse negative value",
+			"-15ms",
 			positiveDuration{},
 			true,
 		},
 		{
-			"PositiveDurationSet returns error for trying to parse empty string",
-			args{
-				"",
-			},
+			"ParsePositiveDuration returns error for trying to parse empty string",
+			"",
 			positiveDuration{},
 			true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parsePositiveDuration(tt.args.s)
+			got, err := parsePositiveDuration(tt.testInput)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parsePositiveDuration() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -54,6 +54,16 @@ func TestCreateClientWithRetries(t *testing.T) {
 			want:            nil,
 			wantErr:         true,
 		},
+		{
+			name: "getClient returns an error after negative retries cli arg is passed",
+			args: args{
+				client:  nil,
+				err:     errors.New("error"),
+				retries: -3,
+			},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -67,13 +77,13 @@ func TestCreateClientWithRetries(t *testing.T) {
 
 			actualRetries := invocations - 1
 
-			if actualRetries != tt.expectedRetries {
+			if err != nil && tt.wantErr {
+				return
+			} else if actualRetries != tt.expectedRetries {
 				t.Errorf("createClientWithRetries() got %v retries, expected %v", actualRetries, tt.expectedRetries)
 				return
 			} else if (err != nil) != tt.wantErr {
 				t.Errorf("createClientWithRetries() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			} else if err != nil && tt.wantErr {
 				return
 			} else if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("createClientWithRetries() = %v, want %v", got, tt.want)

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -134,7 +134,7 @@ func TestCreatePositiveDurationFlag(t *testing.T) {
 			if err != nil && tt.wantErr == true {
 				return
 			} else if err != nil {
-				t.Errorf("Got: %v. Expected no error, ", err)
+				t.Errorf("Got: %v. Expected no error", err)
 			}
 
 			err = flag.CommandLine.Parse(os.Args[1:])
@@ -156,7 +156,7 @@ func TestCreatePositiveDurationFlag(t *testing.T) {
 				t.Errorf("Got: %v. Expected no error", err)
 			}
 			if testFlag.Value.String() != tt.update {
-				t.Errorf("Got: %v. Expected flag to be update to %v.", testFlag.Value, tt.update)
+				t.Errorf("Got: %v. Expected flag to be updated to %v.", testFlag.Value, tt.update)
 			}
 		})
 	}

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -67,13 +67,13 @@ func TestCreateClientWithRetries(t *testing.T) {
 
 			actualRetries := invocations - 1
 
-			if err != nil && tt.wantErr {
-				return
-			} else if actualRetries != tt.expectedRetries {
+			if actualRetries != tt.expectedRetries {
 				t.Errorf("createClientWithRetries() got %v retries, expected %v", actualRetries, tt.expectedRetries)
 				return
 			} else if (err != nil) != tt.wantErr {
 				t.Errorf("createClientWithRetries() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			} else if err != nil && tt.wantErr {
 				return
 			} else if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("createClientWithRetries() = %v, want %v", got, tt.want)

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -11,7 +11,7 @@ func TestCreateClientWithRetries(t *testing.T) {
 	type args struct {
 		client        interface{}
 		err           error
-		retries       int
+		retries       uint
 		retryInterval time.Duration
 	}
 
@@ -53,16 +53,6 @@ func TestCreateClientWithRetries(t *testing.T) {
 			expectedRetries: 3,
 			want:            nil,
 			wantErr:         true,
-		},
-		{
-			name: "getClient returns an error after negative retries cli arg is passed",
-			args: args{
-				client:  nil,
-				err:     errors.New("error"),
-				retries: -3,
-			},
-			want:    nil,
-			wantErr: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Command
`$ go run exporter.go -nginx.retries -1`
#### Expected
Catch error and return it.
#### Actual
Exits in non graceful manner.
```
panic: interface conversion: interface {} is nil, not *client.NginxClient

goroutine 1 [running]:
main.main()
/go/src/github.com/nginxinc/nginx-prometheus-exporter/exporter.go:167 +0xb11
```

#### Proposed changes
```
invalid value "-1" for flag -nginx.retries: parse error
Usage of ./nginx-prometheus-exporter:
  -nginx.plus
    	Start the exporter for NGINX Plus. By default, the exporter is started for NGINX. The default value can be overwritten by NGINX_PLUS environment variable.
  -nginx.retries uint
    	A number of retries the exporter will make on start to connect to the NGINX stub_status page/NGINX Plus API before exiting with an error. The default value can be overwritten by NGINX_RETRIES environment variable.
  -nginx.retry-interval duration
    	An interval between retries to connect to the NGINX stub_status page/NGINX Plus API on start. The default value can be overwritten by NGINX_RETRY_INTERVAL environment variable. (default 5s)
...
  -web.telemetry-path string
    	A path under which to expose metrics. The default value can be overwritten by TELEMETRY_PATH environment variable. (default "/metrics")
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/master/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

