### PR TITLE
Fix sleep for first retry

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -102,7 +102,7 @@ func createClientWithRetries(getClient func() (interface{}, error), retries uint
 		if err == nil {
 			return nginxClient, nil
 		}
-		if i > 0 {
+		if i < int(retries) {
 			log.Printf("Could not create Nginx Client. Retrying in %v...", retryInterval)
 			time.Sleep(retryInterval)
 		}


### PR DESCRIPTION
### Proposed changes
The exporter does not sleep in between the first connection attempt and the first retry attempt.

Introduced in: https://github.com/nginxinc/nginx-prometheus-exporter/commit/b499ca793a540113d9690c035af4756544a24d2b

BEFORE fix(with additional debug logs for clarity)
```
$ ./nginx-prometheus-exporter -nginx.scrape-uri=wrong.nginx.com -nginx.retries=7 -nginx.retry-interval=5s
2019/04/08 16:31:18 Starting NGINX Prometheus Exporter Version=0.3.0 GitCommit=d35d429
2019/04/08 16:31:18 TRY
2019/04/08 16:31:18 RETRY 1
2019/04/08 16:31:18 Could not create Nginx Client. Retrying in 5s...
2019/04/08 16:31:23 RETRY 2
2019/04/08 16:31:23 Could not create Nginx Client. Retrying in 5s...
```

AFTER fix(with additional debug logs)
```
$ ./nginx-prometheus-exporter -nginx.scrape-uri=wrong.nginx.com -nginx.retries=7 -nginx.retry-interval=5s
2019/04/08 16:30:27 Starting NGINX Prometheus Exporter Version=0.3.0 GitCommit=d35d429
2019/04/08 16:30:27 TRY
2019/04/08 16:30:27 Could not create Nginx Client. Retrying in 5s...
2019/04/08 16:30:32 RETRY 1
2019/04/08 16:30:32 Could not create Nginx Client. Retrying in 5s...
2019/04/08 16:30:37 RETRY 2
2019/04/08 16:30:37 Could not create Nginx Client. Retrying in 5s...
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/master/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

