### PR TITLE
Do not expose zone sync metric if not present

### DIFF
--- a/collector/nginx_plus.go
+++ b/collector/nginx_plus.go
@@ -303,23 +303,25 @@ func (c *NginxPlusCollector) Collect(ch chan<- prometheus.Metric) {
 			prometheus.GaugeValue, float64(upstream.Zombies), name)
 	}
 
-	for name, zone := range stats.StreamZoneSync.Zones {
-		ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["records_pending"],
-			prometheus.GaugeValue, float64(zone.RecordsPending), name)
-		ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["records_total"],
-			prometheus.GaugeValue, float64(zone.RecordsTotal), name)
-	}
+	if stats.StreamZoneSync != nil {
+		for name, zone := range stats.StreamZoneSync.Zones {
+			ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["records_pending"],
+				prometheus.GaugeValue, float64(zone.RecordsPending), name)
+			ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["records_total"],
+				prometheus.GaugeValue, float64(zone.RecordsTotal), name)
+		}
 
-	ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["bytes_in"],
-		prometheus.CounterValue, float64(stats.StreamZoneSync.Status.BytesIn))
-	ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["bytes_out"],
-		prometheus.CounterValue, float64(stats.StreamZoneSync.Status.BytesOut))
-	ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["msgs_in"],
-		prometheus.CounterValue, float64(stats.StreamZoneSync.Status.MsgsIn))
-	ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["msgs_out"],
-		prometheus.CounterValue, float64(stats.StreamZoneSync.Status.MsgsOut))
-	ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["nodes_online"],
-		prometheus.GaugeValue, float64(stats.StreamZoneSync.Status.NodesOnline))
+		ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["bytes_in"],
+			prometheus.CounterValue, float64(stats.StreamZoneSync.Status.BytesIn))
+		ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["bytes_out"],
+			prometheus.CounterValue, float64(stats.StreamZoneSync.Status.BytesOut))
+		ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["msgs_in"],
+			prometheus.CounterValue, float64(stats.StreamZoneSync.Status.MsgsIn))
+		ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["msgs_out"],
+			prometheus.CounterValue, float64(stats.StreamZoneSync.Status.MsgsOut))
+		ch <- prometheus.MustNewConstMetric(c.streamZoneSyncMetrics["nodes_online"],
+			prometheus.GaugeValue, float64(stats.StreamZoneSync.Status.NodesOnline))
+	}
 }
 
 var upstreamServerStates = map[string]float64{

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/nginxinc/nginx-prometheus-exporter
 go 1.12
 
 require (
-	github.com/nginxinc/nginx-plus-go-client v0.0.0-20190529112308-8f20f677a8bf
+	github.com/nginxinc/nginx-plus-go-client v0.3.1
 	github.com/prometheus/client_golang v0.9.2
 )

--- a/go.sum
+++ b/go.sum
@@ -4,14 +4,8 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/nginxinc/nginx-plus-go-client v0.0.0-20190326123225-e0cdc4be0c7f h1:3DdSFnaXSvhgn9RhiptJiudBHmFq+wDRccrJwhrwHlg=
-github.com/nginxinc/nginx-plus-go-client v0.0.0-20190522143815-28e3fc49525c h1:xyY2/MuxVbzzEXAJkaFWERM3RtCaz/IX/jBOJZkZVc4=
-github.com/nginxinc/nginx-plus-go-client v0.0.0-20190522143815-28e3fc49525c/go.mod h1:DBAmdDP71tOhgFPdCMVusegzdKmLVpVL0nVcMX17pbY=
-github.com/nginxinc/nginx-plus-go-client v0.0.0-20190524095408-9fb6bf19a64e h1:7DbTRinSESf1WTnnGxoD7o0bvnFHIxVINTaMNYVFiHo=
-github.com/nginxinc/nginx-plus-go-client v0.0.0-20190524144844-4d90184fc765 h1:SwxKOmnP+AELWdMDac0N7x7dN1vxoKjK5i2x2qYjOGQ=
-github.com/nginxinc/nginx-plus-go-client v0.0.0-20190524144844-4d90184fc765/go.mod h1:DBAmdDP71tOhgFPdCMVusegzdKmLVpVL0nVcMX17pbY=
-github.com/nginxinc/nginx-plus-go-client v0.0.0-20190529112308-8f20f677a8bf h1:QFUdFoJTsB60JpskBNicEQhu220DEL7UV8SJKUwdi3o=
-github.com/nginxinc/nginx-plus-go-client v0.0.0-20190529112308-8f20f677a8bf/go.mod h1:DBAmdDP71tOhgFPdCMVusegzdKmLVpVL0nVcMX17pbY=
+github.com/nginxinc/nginx-plus-go-client v0.3.1 h1:oj3tG3v5Ei8v8RccCyGurpVE0jrBFp+EX08qIaaVkm4=
+github.com/nginxinc/nginx-plus-go-client v0.3.1/go.mod h1:DBAmdDP71tOhgFPdCMVusegzdKmLVpVL0nVcMX17pbY=
 github.com/prometheus/client_golang v0.9.2 h1:awm861/B8OKDd2I/6o1dy3ra4BamzKhYOiGItCeZ740=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 h1:idejC8f05m9MGOsuEi1ATq9shN03HrxNkD/luQvxCv8=

--- a/vendor/github.com/nginxinc/nginx-plus-go-client/client/nginx.go
+++ b/vendor/github.com/nginxinc/nginx-plus-go-client/client/nginx.go
@@ -88,7 +88,7 @@ type Stats struct {
 	Upstreams         Upstreams
 	StreamServerZones StreamServerZones
 	StreamUpstreams   StreamUpstreams
-	StreamZoneSync    StreamZoneSync
+	StreamZoneSync    *StreamZoneSync
 }
 
 // NginxInfo contains general information about NGINX Plus.
@@ -764,7 +764,7 @@ func (client *NginxClient) GetStats() (*Stats, error) {
 		StreamServerZones: *streamZones,
 		Upstreams:         *upstreams,
 		StreamUpstreams:   *streamUpstreams,
-		StreamZoneSync:    *streamZoneSync,
+		StreamZoneSync:    streamZoneSync,
 	}, nil
 }
 
@@ -855,9 +855,8 @@ func (client *NginxClient) getStreamZoneSync() (*StreamZoneSync, error) {
 	err := client.get("stream/zone_sync", &streamZoneSync)
 	if err != nil {
 		if err, ok := err.(*internalError); ok {
-
 			if err.Code == pathNotFoundCode {
-				return &streamZoneSync, nil
+				return nil, nil
 			}
 		}
 		return nil, fmt.Errorf("failed to get stream zone sync: %v", err)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,7 @@ github.com/beorn7/perks/quantile
 github.com/golang/protobuf/proto
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/nginxinc/nginx-plus-go-client v0.0.0-20190529112308-8f20f677a8bf
+# github.com/nginxinc/nginx-plus-go-client v0.3.1
 github.com/nginxinc/nginx-plus-go-client/client
 # github.com/prometheus/client_golang v0.9.2
 github.com/prometheus/client_golang/prometheus


### PR DESCRIPTION
### Proposed changes
* If zone sync metrics are not present (`nil`) do not expose them, for consistency.


