### PR TITLE
Fix stream server zones session metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/nginxinc/nginx-prometheus-exporter
 go 1.12
 
 require (
-	github.com/nginxinc/nginx-plus-go-client v0.3.1
+	github.com/nginxinc/nginx-plus-go-client v0.3.2-0.20190716103443-6b51388053dd
 	github.com/prometheus/client_golang v0.9.2
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/nginxinc/nginx-prometheus-exporter
 go 1.12
 
 require (
-	github.com/nginxinc/nginx-plus-go-client v0.3.2-0.20190716103443-6b51388053dd
+	github.com/nginxinc/nginx-plus-go-client v0.4.0
 	github.com/prometheus/client_golang v0.9.2
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/nginxinc/nginx-plus-go-client v0.3.1 h1:oj3tG3v5Ei8v8RccCyGurpVE0jrBFp+EX08qIaaVkm4=
-github.com/nginxinc/nginx-plus-go-client v0.3.1/go.mod h1:DBAmdDP71tOhgFPdCMVusegzdKmLVpVL0nVcMX17pbY=
+github.com/nginxinc/nginx-plus-go-client v0.3.2-0.20190716103443-6b51388053dd h1:XZJZWn9hI6wr8dxuycWuDO22moUwX2UhLzVWfSP5euw=
+github.com/nginxinc/nginx-plus-go-client v0.3.2-0.20190716103443-6b51388053dd/go.mod h1:DBAmdDP71tOhgFPdCMVusegzdKmLVpVL0nVcMX17pbY=
 github.com/prometheus/client_golang v0.9.2 h1:awm861/B8OKDd2I/6o1dy3ra4BamzKhYOiGItCeZ740=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 h1:idejC8f05m9MGOsuEi1ATq9shN03HrxNkD/luQvxCv8=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/nginxinc/nginx-plus-go-client v0.3.2-0.20190716103443-6b51388053dd h1:XZJZWn9hI6wr8dxuycWuDO22moUwX2UhLzVWfSP5euw=
-github.com/nginxinc/nginx-plus-go-client v0.3.2-0.20190716103443-6b51388053dd/go.mod h1:DBAmdDP71tOhgFPdCMVusegzdKmLVpVL0nVcMX17pbY=
+github.com/nginxinc/nginx-plus-go-client v0.4.0 h1:/kBbXz3FXqc0y1d+so9CuXgvnaWNcV6yOcFZ+9EUGjE=
+github.com/nginxinc/nginx-plus-go-client v0.4.0/go.mod h1:DBAmdDP71tOhgFPdCMVusegzdKmLVpVL0nVcMX17pbY=
 github.com/prometheus/client_golang v0.9.2 h1:awm861/B8OKDd2I/6o1dy3ra4BamzKhYOiGItCeZ740=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 h1:idejC8f05m9MGOsuEi1ATq9shN03HrxNkD/luQvxCv8=

--- a/vendor/github.com/nginxinc/nginx-plus-go-client/client/nginx.go
+++ b/vendor/github.com/nginxinc/nginx-plus-go-client/client/nginx.go
@@ -29,6 +29,7 @@ type versions []int
 type UpstreamServer struct {
 	ID          int    `json:"id,omitempty"`
 	Server      string `json:"server"`
+	MaxConns    int    `json:"max_conns"`
 	MaxFails    int    `json:"max_fails"`
 	FailTimeout string `json:"fail_timeout,omitempty"`
 	SlowStart   string `json:"slow_start,omitempty"`
@@ -38,6 +39,7 @@ type UpstreamServer struct {
 type StreamUpstreamServer struct {
 	ID          int    `json:"id,omitempty"`
 	Server      string `json:"server"`
+	MaxConns    int    `json:"max_conns"`
 	MaxFails    int    `json:"max_fails"`
 	FailTimeout string `json:"fail_timeout,omitempty"`
 	SlowStart   string `json:"slow_start,omitempty"`
@@ -156,7 +158,7 @@ type StreamZoneSync struct {
 	Status StreamZoneSyncStatus
 }
 
-// SyncZone represents the syncronization status of a shared memory zone
+// SyncZone represents the synchronization status of a shared memory zone
 type SyncZone struct {
 	RecordsPending uint64 `json:"records_pending"`
 	RecordsTotal   uint64 `json:"records_total"`
@@ -184,8 +186,8 @@ type Responses struct {
 // Sessions represents stream session related stats.
 type Sessions struct {
 	Sessions2xx uint64 `json:"2xx"`
-	Sessions4xx uint64 `josn:"4xx"`
-	Sessions5xx uint64 `josn:"5xx"`
+	Sessions4xx uint64 `json:"4xx"`
+	Sessions5xx uint64 `json:"5xx"`
 	Total       uint64
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,7 @@ github.com/beorn7/perks/quantile
 github.com/golang/protobuf/proto
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/nginxinc/nginx-plus-go-client v0.3.1
+# github.com/nginxinc/nginx-plus-go-client v0.3.2-0.20190716103443-6b51388053dd
 github.com/nginxinc/nginx-plus-go-client/client
 # github.com/prometheus/client_golang v0.9.2
 github.com/prometheus/client_golang/prometheus

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,7 @@ github.com/beorn7/perks/quantile
 github.com/golang/protobuf/proto
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/nginxinc/nginx-plus-go-client v0.3.2-0.20190716103443-6b51388053dd
+# github.com/nginxinc/nginx-plus-go-client v0.4.0
 github.com/nginxinc/nginx-plus-go-client/client
 # github.com/prometheus/client_golang v0.9.2
 github.com/prometheus/client_golang/prometheus


### PR DESCRIPTION
### Proposed changes
Session `4xx` and `5xx` metrics were fixed in https://github.com/nginxinc/nginx-plus-go-client/commit/f8b65d22607173ddb02eaef76833ea4f7658572b. 
This PR updates that dependency to that commit in order to fix the issue.

### Before the fix
* The exporter would not scrape this values correctly and would always report the metrics as `0`.

### After the fix
* The exporter correctly scrapes and exports these metrics.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/master/CONTRIBUTING.md) guide
- [ ] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

