### PR TITLE
Release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### 0.4.2
+
+BUGFIXES:
+* [60](https://github.com/nginxinc/nginx-prometheus-exporter/pull/60): *Fix session metrics for stream server zones*. Session metrics with a status of `4xx` or `5xx` are now correctly reported. Previously they were always reported as `0`.
+
+UPGRADE:
+* Use the 0.4.2 image from our DockerHub: `nginx/nginx-prometheus-exporter:0.4.2`
+* Download the latest binaries from [GitHub releases page](https://github.com/nginxinc/nginx-prometheus-exporter/releases/tag/v0.4.2).
+
+COMPATIBILITY:
+* NGINX 0.1.18 or newer.
+* NGINX Plus R18 or newer.
+
 ### 0.4.1
 
 BUGFIXES:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 0.4.1
+VERSION = 0.4.2
 PREFIX = nginx/nginx-prometheus-exporter
 TAG = $(VERSION)
 GIT_COMMIT = $(shell git rev-parse --short HEAD)

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ To start the exporter we use the [docker run](https://docs.docker.com/engine/ref
 
 * To export NGINX metrics, run:
     ```
-    $ docker run -p 9113:9113 nginx/nginx-prometheus-exporter:0.4.1 -nginx.scrape-uri http://<nginx>:8080/stub_status
+    $ docker run -p 9113:9113 nginx/nginx-prometheus-exporter:0.4.2 -nginx.scrape-uri http://<nginx>:8080/stub_status
     ```
     where `<nginx>` is the IP address/DNS name, through which NGINX is available.
 
 * To export NGINX Plus metrics, run:
     ```
-    $ docker run -p 9113:9113 nginx/nginx-prometheus-exporter:0.4.1 -nginx.plus -nginx.scrape-uri http://<nginx-plus>:8080/api
+    $ docker run -p 9113:9113 nginx/nginx-prometheus-exporter:0.4.2 -nginx.plus -nginx.scrape-uri http://<nginx-plus>:8080/api
     ```
     where `<nginx-plus>` is the IP address/DNS name, through which NGINX Plus is available.
 


### PR DESCRIPTION
### Proposed changes

* [60](https://github.com/nginxinc/nginx-prometheus-exporter/pull/60): *Fix session metrics for stream server zones*. Session metrics with a status of `4xx` or `5xx` are now correctly reported. Previously they were always reported as `0`.



