### PR TITLE
nginx: Fix nginx_up in grafana dashbpord

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -136,7 +136,7 @@
             "tableColumn": "",
             "targets": [
                 {
-                    "expr": "nginx_up{instance=\"$instance\"}",
+                    "expr": "nginx_up{instance=~\"$instance\"}",
                     "format": "time_series",
                     "instant": false,
                     "intervalFactor": 1,


### PR DESCRIPTION
The nginx_up{instance...} syntax requires ~ so that it's like:

nginx_up{instance=~"$instance"}