### PR TITLE
Update Go version to 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 services:
 - docker
 go:
-- "1.12"
+- "1.13"
 script:
 - echo "Nginx Prometheus Exporter - commit:${TRAVIS_COMMIT}"
 - make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12 as builder
+FROM golang:1.13 as builder
 ARG VERSION
 ARG GIT_COMMIT
 WORKDIR /go/src/github.com/nginxinc/nginx-prometheus-exporter

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nginxinc/nginx-prometheus-exporter
 
-go 1.12
+go 1.13
 
 require (
 	github.com/nginxinc/nginx-plus-go-client v0.5.0


### PR DESCRIPTION
### Proposed changes
Go 1.13 was released recently.
We need to update our projects to use Go 1.13
Make sure both travis files (if present) and Makefiles are updated.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/master/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

