### PR TITLE
Do not assume default datasource in Grafana panels

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -57,6 +57,7 @@
     "links": [],
     "panels": [
         {
+            "datasource": "${DS_PROMETHEUS}",
             "collapsed": false,
             "gridPos": {
                 "h": 1,
@@ -70,6 +71,7 @@
             "type": "row"
         },
         {
+            "datasource": "${DS_PROMETHEUS}",
             "cacheTimeout": null,
             "colorBackground": true,
             "colorPostfix": false,
@@ -164,6 +166,7 @@
             "valueName": "current"
         },
         {
+            "datasource": "${DS_PROMETHEUS}",
             "collapsed": false,
             "gridPos": {
                 "h": 1,
@@ -177,6 +180,7 @@
             "type": "row"
         },
         {
+            "datasource": "${DS_PROMETHEUS}",
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
@@ -277,6 +281,7 @@
             }
         },
         {
+            "datasource": "${DS_PROMETHEUS}",
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
@@ -387,6 +392,7 @@
             }
         },
         {
+            "datasource": "${DS_PROMETHEUS}",
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,


### PR DESCRIPTION
### Proposed changes
Fixes #69

Before, each panel assumed the default Datasource. If Prometheus was not the default datasource the data was not correct.

With this, we force that all panels need to have the same value as the variable `${DS_PROMETHEUS}` which is set when importing the panel. 




