### PR TITLE
exporter: link to actual metricsPath

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -386,7 +386,6 @@ func main() {
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		_, err := fmt.Fprintf(w, `<!DOCTYPE html>
-			<meta charset="utf-8">
 			<title>NGINX Exporter</title>
 			<h1>NGINX Exporter</h1>
 			<p><a href=%q>Metrics</a></p>`,

--- a/exporter.go
+++ b/exporter.go
@@ -383,14 +383,14 @@ func main() {
 		registry.MustRegister(collector.NewNginxCollector(ossClient.(*client.NginxClient), "nginx", constLabels.labels))
 	}
 	http.Handle(*metricsPath, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		_, err := w.Write([]byte(`<html>
-			<head><title>NGINX Exporter</title></head>
-			<body>
+		_, err := fmt.Fprintf(w, `<!DOCTYPE html>
+			<meta charset="utf-8">
+			<title>NGINX Exporter</title>
 			<h1>NGINX Exporter</h1>
-			<p><a href='/metrics'>Metrics</a></p>
-			</body>
-			</html>`))
+			<p><a href=%q>Metrics</a></p>`,
+			*metricsPath)
 		if err != nil {
 			log.Printf("Error while sending a response for the '/' path: %v", err)
 		}


### PR DESCRIPTION
### Proposed changes

The HTML on the `/` path show an hardcoded value for the metrics path. This fixes it.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/master/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

