### PR TITLE
Fix default prometheus datasource was not found error

### DIFF
--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -489,6 +489,25 @@
     "templating": {
         "list": [
             {
+                "current": {
+                  "selected": false,
+                  "tags": [],
+                  "text": "default",
+                  "value": "default"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "datasource",
+                "multi": false,
+                "name": "DS_PROMETHEUS",
+                "options": [],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+            },
+            {
                 "allValue": null,
                 "current": {},
                 "datasource": "${DS_PROMETHEUS}",


### PR DESCRIPTION
### Proposed changes
When using this Grafana dashboard, we get the following error: `Datasource named ${DS_PROMETHEUS} was not found`. This change fixes this issue.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ X ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/master/CONTRIBUTING.md) guide
- [ X ] I have proven my fix is effective or that my feature works
- [ X ] I have checked that all unit tests pass after adding my changes
- [ X ] I have ensured the README is up to date
- [ X ] I have rebased my branch onto master
- [ X ] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

