### PR TITLE
Add variable labels to Upstream Servers and Server Zones metrics

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -372,7 +372,8 @@ func main() {
 		if err != nil {
 			log.Fatalf("Could not create Nginx Plus Client: %v", err)
 		}
-		registry.MustRegister(collector.NewNginxPlusCollector(plusClient.(*plusclient.NginxClient), "nginxplus", constLabels.labels))
+		variableLabelNames := collector.NewVariableLabelNames(nil, nil)
+		registry.MustRegister(collector.NewNginxPlusCollector(plusClient.(*plusclient.NginxClient), "nginxplus", variableLabelNames, constLabels.labels))
 	} else {
 		ossClient, err := createClientWithRetries(func() (interface{}, error) {
 			return client.NewNginxClient(httpClient, *scrapeURI)


### PR DESCRIPTION
### Proposed changes
Add optional support to add variable labels to Upstream Server and Server Zone metrics when using the prom exporter as a library.

This change does not affect when the exporter is run as a binary, it's basically a change needed by the Ingress Controller when using this code, to make sure we can create relations between Ingress Controller resources and NGINX configuration to add labels to the metrics.



