### PR TITLE
Use same style of release names as official exporters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,18 +34,18 @@ $(BUILD_DIR)/nginx-prometheus-exporter-linux-i386:
 
 release: $(BUILD_DIR)/nginx-prometheus-exporter-linux-amd64 $(BUILD_DIR)/nginx-prometheus-exporter-linux-i386
 	mv $(BUILD_DIR)/nginx-prometheus-exporter-linux-amd64 $(BUILD_DIR)/nginx-prometheus-exporter && \
-	tar czf $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-amd64.tar.gz -C $(BUILD_DIR) nginx-prometheus-exporter && \
+	tar czf $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG).linux-amd64.tar.gz -C $(BUILD_DIR) nginx-prometheus-exporter && \
 	rm $(BUILD_DIR)/nginx-prometheus-exporter
 
 	mv $(BUILD_DIR)/nginx-prometheus-exporter-linux-i386 $(BUILD_DIR)/nginx-prometheus-exporter && \
-	tar czf $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-i386.tar.gz -C $(BUILD_DIR) nginx-prometheus-exporter && \
+	tar czf $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG).linux-i386.tar.gz -C $(BUILD_DIR) nginx-prometheus-exporter && \
 	rm $(BUILD_DIR)/nginx-prometheus-exporter
 
-	shasum -a 256 $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-amd64.tar.gz $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-i386.tar.gz|sed "s|$(BUILD_DIR)/||" > $(BUILD_DIR)/sha256sums.txt
+	shasum -a 256 $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG).linux-amd64.tar.gz $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG).linux-i386.tar.gz|sed "s|$(BUILD_DIR)/||" > $(BUILD_DIR)/sha256sums.txt
 
 clean:
-	-rm $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-amd64.tar.gz
-	-rm $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG)-linux-i386.tar.gz
+	-rm $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG).linux-amd64.tar.gz
+	-rm $(BUILD_DIR)/nginx-prometheus-exporter-$(TAG).linux-i386.tar.gz
 	-rm $(BUILD_DIR)/sha256sums.txt
 	-rmdir $(BUILD_DIR)
 	-rm nginx-prometheus-exporter


### PR DESCRIPTION
### Proposed changes
The official prometheus exporters use all the same naming scheme. You used a `-` instead of a `.` for whatever reason.
To make it easier to download exporters, in standardized ways, it would be good if everyone follows this schema.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/master/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

