### PR TITLE
Use static-debian10:nonroot instead of static:latest

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,7 +9,7 @@ COPY collector ./collector
 COPY client ./client
 RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -installsuffix cgo -ldflags "-X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}" -o exporter .
 
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static-debian10:nonroot
 COPY --from=builder /go/src/github.com/nginxinc/nginx-prometheus-exporter/exporter /usr/bin/
 
 USER 1001:1001


### PR DESCRIPTION
Otherwise you will get the following error message:
```
docker pull gcr.io/distroless/static:latest
latest: Pulling from distroless/static
no matching manifest for linux/arm/v7 in the manifest list entries
```