### PR TITLE
add tls support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,13 @@ Usage of ./nginx-prometheus-exporter:
   -web.listen-address string
         An address or unix domain socket path to listen on for web interface and telemetry. The default value can be overwritten by LISTEN_ADDRESS environment variable. (default ":9113")
   -web.telemetry-path string
-        A path under which to expose metrics. The default value can be overwritten by TELEMETRY_PATH environment variable. (default "/metrics")
+        A path under which to expose metrics. The default value can be overwritten by TELEMETRY_PATH environment variable. (default "/metrics")  
+  -web.secured-metrics
+        Expose metrics using https. The default value can be overwritten by SECURED_METRICS variable.  (default false)
+  -web.ssl-server-cert string
+        Path to the PEM encoded certificate for the nginx-exporter metrics server(when web.secured-metrics=true). The default value can be overwritten by SSL_SERVER_CERT variable.
+  -web.ssl-server-key string
+        Path to the PEM encoded key for the nginx-exporter metrics server (when web.secured-metrics=true). The default value can be overwritten by SSL_SERVER_KEY variable.
   -version
         Display the NGINX exporter version. (default false)
 ```


### PR DESCRIPTION
### Proposed changes
As some high secured environments should have tls comms even for metrics, this PR address to close that gap and makes serve metrics using https an option.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/master/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

