### PR TITLE
Add support for more platforms, push to Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
   unit-tests:
     name: Unit Tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -42,12 +42,10 @@ jobs:
 
   build:
     name: Build Image
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Build Prometheus-Exporter
-        run: make nginx-prometheus-exporter
       - name: Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
@@ -59,11 +57,20 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: --rm-dist --debug --skip-publish --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Image
         uses: docker/build-push-action@v2
         with:
           file: build/Dockerfile
           context: '.'
+          target: local
+          platforms: linux/arm,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           tags: nginx/nginx-prometheus-exporter:${{ github.sha }}
@@ -71,7 +78,7 @@ jobs:
 
   release-docker:
     name: Release Image
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [build, unit-tests]
     if:
       github.repository == 'nginxinc/nginx-prometheus-exporter' &&
@@ -99,11 +106,20 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Push to Dockerhub
         uses: docker/build-push-action@v2
         with:
           file: build/Dockerfile
           context: '.'
+          target: local
+          platforms: linux/arm,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x
           tags: |
             nginx/nginx-prometheus-exporter:latest
             nginx/nginx-prometheus-exporter:${{ steps.get_version.outputs.GIT_TAG }}
@@ -117,17 +133,10 @@ jobs:
             publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   notify:
     name: Notify
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: release-docker
     if: always() && github.ref == 'refs/heads/master'
     steps:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,9 +16,15 @@ builds:
       - amd64
       - arm
       - arm64
+      - ppc64le
+      - mips64le
+      - s390x
     goarm:
+      - 5
       - 6
       - 7
+    gomips:
+      - softfloat
     flags:
       - -mod=vendor
 checksum:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test:
 
 .PHONY: container
 container:
-	docker build --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) -f $(DOCKERFILEPATH)/$(DOCKERFILE) -t $(PREFIX):$(TAG) .
+	docker build --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --target container -f $(DOCKERFILEPATH)/$(DOCKERFILE) -t $(PREFIX):$(TAG) .
 
 .PHONY: push
 push: container

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,17 +1,28 @@
-FROM golang:1.16 as builder
+FROM golang:1.16-alpine as builder
 ARG VERSION
 ARG GIT_COMMIT
+ARG TARGETARCH
+
 WORKDIR /go/src/github.com/nginxinc/nginx-prometheus-exporter
 COPY *.go ./
 COPY vendor ./vendor
 COPY go.mod go.sum ./
 COPY collector ./collector
 COPY client ./client
-RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -ldflags "-X main.version=${VERSION} -X main.commit=${GIT_COMMIT}" -o exporter .
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -mod=vendor -a -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${GIT_COMMIT}" -o nginx-prometheus-exporter .
 
-FROM gcr.io/distroless/static-debian10:nonroot
-COPY --from=builder /go/src/github.com/nginxinc/nginx-prometheus-exporter/exporter /usr/bin/
 
+FROM gcr.io/distroless/static-debian10:nonroot as base
 USER 1001:1001
+ENTRYPOINT [ "/usr/bin/nginx-prometheus-exporter" ]
 
-ENTRYPOINT [ "/usr/bin/exporter" ]
+
+FROM base as container
+COPY --from=builder /go/src/github.com/nginxinc/nginx-prometheus-exporter/nginx-prometheus-exporter /usr/bin/
+
+
+FROM base as local
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+COPY dist/nginx-prometheus-exporter_linux_$TARGETARCH${TARGETVARIANT:+_7}/nginx-prometheus-exporter /usr/bin


### PR DESCRIPTION
- Building binaries for more versions of arm, 386, ppc64le, mips64le and s390x
- Building docker images for ARM and ppc64 (other platforms are not supported by distroless docker image)
