### PR TITLE
Refactor for go 1.16

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,3 @@
-env:
-  - GO111MODULE=on
 before:
   hooks:
     - make clean

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ export DOCKER_BUILDKIT = 1
 
 .PHONY: nginx-prometheus-exporter
 nginx-prometheus-exporter:
-	GO111MODULE=on CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$(VERSION) -X main.commit=$(GIT_COMMIT) -X main.date=$(DATE)" -o nginx-prometheus-exporter
+	CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$(VERSION) -X main.commit=$(GIT_COMMIT) -X main.date=$(DATE)" -o nginx-prometheus-exporter
 
 .PHONY: lint
 lint:
@@ -20,7 +20,7 @@ lint:
 
 .PHONY: test
 test:
-	GO111MODULE=on go test ./...
+	go test ./...
 
 .PHONY: container
 container:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,7 @@ RUN go mod download
 COPY *.go ./
 COPY collector ./collector
 COPY client ./client
-RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath -a -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${GIT_COMMIT} -X main.date=${DATE}" -o nginx-prometheus-exporter .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath -a -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${GIT_COMMIT} -X main.date=${DATE}" -o nginx-prometheus-exporter .
 
 
 FROM scratch as intermediate

--- a/client/nginx.go
+++ b/client/nginx.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -53,7 +53,7 @@ func (client *NginxClient) GetStubStats() (*StubStats, error) {
 		return nil, fmt.Errorf("expected %v response, got %v", http.StatusOK, resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read the response body: %v", err)
 	}

--- a/exporter.go
+++ b/exporter.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -327,7 +326,7 @@ func main() {
 
 	sslConfig := &tls.Config{InsecureSkipVerify: !*sslVerify}
 	if *sslCaCert != "" {
-		caCert, err := ioutil.ReadFile(*sslCaCert)
+		caCert, err := os.ReadFile(*sslCaCert)
 		if err != nil {
 			log.Fatalf("Loading CA cert failed: %v", err)
 		}


### PR DESCRIPTION
### Proposed changes
Refactor for go 1.16.     ( Related PR: https://github.com/nginxinc/nginx-prometheus-exporter/pull/160 )
I fixed 2 points.

1. Replace `io/ioutil` with `io` or `os`.
   `io/ioutil` is "deprecated", so I replace with `io` or `os`.
    ref: https://golang.org/doc/go1.16#ioutil

   `io/ioutil` is unlikely to be deleted, but `io` or `os` is better.
    ref: https://twitter.com/_rsc/status/1351676094664110082


2.  Remove `GO111MODULE=on`
    Default value of `GO111MODULE` is `on` from go 1.16.
    So we no longer have to set this each time.
    ref: https://golang.org/doc/go1.16#modules

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/master/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

