### PR TITLE
Perfomance or simple parsing nginx metrics [parseStubStats]

### DIFF
--- a/client/nginx.go
+++ b/client/nginx.go
@@ -1,12 +1,11 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
-	"strings"
 )
 
 // NginxClient allows you to fetch NGINX metrics from the stub_status page.
@@ -76,69 +75,43 @@ func (client *NginxClient) GetStubStats() (*StubStats, error) {
 }
 
 func parseStubStats(data []byte, stats *StubStats) error {
-	dataStr := string(data)
-
-	parts := strings.Split(dataStr, "\n")
-	if len(parts) != 5 {
-		return fmt.Errorf("invalid input %q", dataStr)
+	if bytes.Count(data, []byte("\n")) != 4 {
+		return fmt.Errorf("invalid input %s", data)
 	}
 
-	activeConsParts := strings.Split(strings.TrimSpace(parts[0]), " ")
-	if len(activeConsParts) != 3 {
-		return fmt.Errorf("invalid input for active connections %q", parts[0])
+	cnt, value := 0, int64(0)
+	for _, s := range data {
+		if s >= '0' && s <= '9' {
+			value *= 10
+			value += int64(s & 0x0f)
+			continue
+		}
+
+		if value > 0 {
+			switch cnt {
+			case 0:
+				stats.Connections.Active = value
+			case 1:
+				stats.Connections.Accepted = value
+			case 2:
+				stats.Connections.Handled = value
+			case 3:
+				stats.Requests = value
+			case 4:
+				stats.Connections.Reading = value
+			case 5:
+				stats.Connections.Writing = value
+			case 6:
+				stats.Connections.Waiting = value
+			}
+			value = 0
+			cnt++
+		}
 	}
 
-	actCons, err := strconv.ParseInt(activeConsParts[2], 10, 64)
-	if err != nil {
-		return fmt.Errorf("invalid input for active connections %q: %w", activeConsParts[2], err)
+	if cnt != 7 {
+		return fmt.Errorf("invalid input %s", data)
 	}
-	stats.Connections.Active = actCons
-
-	miscParts := strings.Split(strings.TrimSpace(parts[2]), " ")
-	if len(miscParts) != 3 {
-		return fmt.Errorf("invalid input for connections and requests %q", parts[2])
-	}
-
-	acceptedCons, err := strconv.ParseInt(miscParts[0], 10, 64)
-	if err != nil {
-		return fmt.Errorf("invalid input for accepted connections %q: %w", miscParts[0], err)
-	}
-	stats.Connections.Accepted = acceptedCons
-
-	handledCons, err := strconv.ParseInt(miscParts[1], 10, 64)
-	if err != nil {
-		return fmt.Errorf("invalid input for handled connections %q: %w", miscParts[1], err)
-	}
-	stats.Connections.Handled = handledCons
-
-	requests, err := strconv.ParseInt(miscParts[2], 10, 64)
-	if err != nil {
-		return fmt.Errorf("invalid input for requests %q: %w", miscParts[2], err)
-	}
-	stats.Requests = requests
-
-	consParts := strings.Split(strings.TrimSpace(parts[3]), " ")
-	if len(consParts) != 6 {
-		return fmt.Errorf("invalid input for connections %q", parts[3])
-	}
-
-	readingCons, err := strconv.ParseInt(consParts[1], 10, 64)
-	if err != nil {
-		return fmt.Errorf("invalid input for reading connections %q: %w", consParts[1], err)
-	}
-	stats.Connections.Reading = readingCons
-
-	writingCons, err := strconv.ParseInt(consParts[3], 10, 64)
-	if err != nil {
-		return fmt.Errorf("invalid input for writing connections %q: %w", consParts[3], err)
-	}
-	stats.Connections.Writing = writingCons
-
-	waitingCons, err := strconv.ParseInt(consParts[5], 10, 64)
-	if err != nil {
-		return fmt.Errorf("invalid input for waiting connections %q: %w", consParts[5], err)
-	}
-	stats.Connections.Waiting = waitingCons
 
 	return nil
 }


### PR DESCRIPTION
### Proposed changes
![](https://img.shields.io/badge/parseStubStats-Optimization-blue)
```bash
cpu: AMD Ryzen 5 PRO 3500U w/ Radeon Vega Mobile Gfx
BenchmarkParser-8       	  834151	      1601 ns/op	     400 B/op	       5 allocs/op
BenchmarkParserFast-8   	 3204973	       336 ns/op	       0 B/op	       0 allocs/op
BenchmarkParserFmt-8    	   99900	     12160 ns/op	     144 B/op	       7 allocs/op
```

**[AS-IS] Now**:
BenchmarkParser.

**[TO-BE] Variant 1:** 
![](https://img.shields.io/badge/parseStubStats-Perfomance-green)
Improving performance for the Nginx metrics parsing - BenchmarkParserFast. (Current commit)

**[TO-BE] Variant 2**:
![](https://img.shields.io/badge/parseStubStats-Simple-green)
Simple visual templating Nginx metrics, but low performance of the solution - BenchmarkParserFmt.
See more: https://gist.github.com/mirecl/bdd2a88725afe0b7e6e495c9a48e568b

### Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/master/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

