### PR TITLE
Use GitHub cache backend API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,6 @@ jobs:
         uses: docker/setup-buildx-action@v1
         with:
           driver-opts: network=host
-      - name: Cache Docker layers
-        uses: actions/cache@v2.1.6
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - name: Determine GOPATH
         run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
       - name: Setup Golang Environment
@@ -87,8 +80,8 @@ jobs:
           context: '.'
           target: local
           platforms: linux/arm,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x,linux/mips64le,linux/386
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: nginx/nginx-prometheus-exporter:${{ github.sha }}
           push: false
 
@@ -122,13 +115,6 @@ jobs:
         uses: docker/setup-buildx-action@v1
         with:
           driver-opts: network=host
-      - name: Cache Docker layers
-        uses: actions/cache@v2.1.6
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - name: DockerHub Login
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,6 @@ jobs:
           platforms: arm,arm64,ppc64le,s390x,mips64le,386
       - name: Docker Buildx
         uses: docker/setup-buildx-action@v1
-        with:
-          driver-opts: network=host
       - name: Determine GOPATH
         run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
       - name: Setup Golang Environment
@@ -113,8 +111,6 @@ jobs:
           platforms: arm,arm64,ppc64le,s390x,mips64le,386
       - name: Docker Buildx
         uses: docker/setup-buildx-action@v1
-        with:
-          driver-opts: network=host
       - name: DockerHub Login
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
Use the new GHA [cache](https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api) removing the need for an additional action

