### PR TITLE
Use linked copies in Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 FROM golang:1.17 as base
 ARG VERSION
 ARG GIT_COMMIT
@@ -7,22 +8,22 @@ ARG TARGETARCH
 WORKDIR /go/src/github.com/nginxinc/nginx-prometheus-exporter
 
 FROM base as builder
-COPY go.mod go.sum ./
+COPY --link go.mod go.sum ./
 RUN go mod download
-COPY *.go ./
-COPY collector ./collector
-COPY client ./client
+COPY --link *.go ./
+COPY --link collector ./collector
+COPY --link client ./client
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath -a -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${GIT_COMMIT} -X main.date=${DATE}" -o nginx-prometheus-exporter .
 
 
 FROM scratch as intermediate
-COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=base --link /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 USER 1001:1001
 ENTRYPOINT [ "/usr/bin/nginx-prometheus-exporter" ]
 
 
 FROM intermediate as container
-COPY --from=builder /go/src/github.com/nginxinc/nginx-prometheus-exporter/nginx-prometheus-exporter /usr/bin/
+COPY --from=builder --link /go/src/github.com/nginxinc/nginx-prometheus-exporter/nginx-prometheus-exporter /usr/bin/
 
 
 FROM intermediate as goreleaser
@@ -33,4 +34,4 @@ ARG TARGETPLATFORM
 LABEL org.nginx.exporter.image.build.target="${TARGETPLATFORM}"
 LABEL org.nginx.exporter.image.build.version="goreleaser"
 
-COPY dist/nginx-prometheus-exporter_linux_$TARGETARCH${TARGETVARIANT:+_7}*/nginx-prometheus-exporter /usr/bin/
+COPY --link dist/nginx-prometheus-exporter_linux_$TARGETARCH${TARGETVARIANT:+_7}*/nginx-prometheus-exporter /usr/bin/


### PR DESCRIPTION
From the docs https://github.com/moby/buildkit/blob/dockerfile/1.4.0/frontend/dockerfile/docs/syntax.md#linked-copies-copy---link-add---link
>Enabling this flag in `COPY` or `ADD` commands allows you to copy files with enhanced semantics where your files remain independent on their own layer and don't get invalidated when commands on previous layers are changed.

