### PR TITLE
Read Go build info from the binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,4 +140,3 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
-            GIT_COMMIT=${{ github.sha }}

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,9 @@ VERSION = 0.10.0
 TAG = $(VERSION)
 PREFIX = nginx/nginx-prometheus-exporter
 
-DOCKERFILEPATH = build
-DOCKERFILE = Dockerfile
-
-GIT_COMMIT = $(shell git rev-parse HEAD)
-DATE = $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-
-export DOCKER_BUILDKIT = 1
-
 .PHONY: nginx-prometheus-exporter
 nginx-prometheus-exporter:
-	CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$(VERSION) -X main.commit=$(GIT_COMMIT) -X main.date=$(DATE)" -o nginx-prometheus-exporter
+	CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$(VERSION)" -o nginx-prometheus-exporter
 
 .PHONY: build-goreleaser
 build-goreleaser: ## Build all binaries using GoReleaser
@@ -29,7 +21,7 @@ test:
 
 .PHONY: container
 container:
-	docker build --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg DATE=$(DATE) --target container -f $(DOCKERFILEPATH)/$(DOCKERFILE) -t $(PREFIX):$(TAG) .
+	docker build --build-arg VERSION=$(VERSION) --target container -f build/Dockerfile -t $(PREFIX):$(TAG) .
 
 .PHONY: push
 push: container

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,6 @@
 # syntax=docker/dockerfile:1.4
 FROM golang:1.18 as base
 ARG VERSION
-ARG GIT_COMMIT
-ARG DATE
 ARG TARGETARCH
 
 WORKDIR /go/src/github.com/nginxinc/nginx-prometheus-exporter
@@ -13,7 +11,7 @@ RUN go mod download
 COPY --link *.go ./
 COPY --link collector ./collector
 COPY --link client ./client
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath -a -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${GIT_COMMIT} -X main.date=${DATE}" -o nginx-prometheus-exporter .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath -a -ldflags "-s -w -X main.version=${VERSION}" -o nginx-prometheus-exporter .
 
 
 FROM scratch as intermediate


### PR DESCRIPTION
With Go 1.18 it's possible to get `git` info from the binary, removing the need to inject values at build time.
