### PR TITLE
Add ReadHeaderTimeout to http.Server

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -381,7 +381,9 @@ func main() {
 		Transport: userAgentRT,
 	}
 
-	srv := http.Server{}
+	srv := http.Server{
+		ReadHeaderTimeout: 5 * time.Second,
+	}
 
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
Adds timeout to fix 

`G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server (gosec)`