### PR TITLE
Fix typographical error

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Name | Type | Description | Labels
 Name | Type | Description | Labels
 ----|----|----|----|
 `nginxplus_limit_request_passed` | Counter | Total number of requests that were neither limited nor accounted as limited | `zone` |
-`nginxplus_limit_request_rejected` | Counter | Total number of requests that were that were rejected | `zone` |
+`nginxplus_limit_request_rejected` | Counter | Total number of requests that were rejected | `zone` |
 `nginxplus_limit_request_delayed` | Counter | Total number of requests that were delayed | `zone` |
 `nginxplus_limit_request_rejected_dry_run` | Counter | Total number of requests accounted as rejected in the dry run mode | `zone` |
 `nginxplus_limit_request_delayed_dry_run` | Counter | Total number of requests accounted as delayed in the dry run mode | `zone` |

--- a/collector/nginx_plus.go
+++ b/collector/nginx_plus.go
@@ -346,7 +346,7 @@ func NewNginxPlusCollector(nginxClient *plusclient.NginxClient, namespace string
 		limitRequestMetrics: map[string]*prometheus.Desc{
 			"passed":           newLimitRequestMetric(namespace, "passed", "Total number of requests that were neither limited nor accounted as limited", constLabels),
 			"delayed":          newLimitRequestMetric(namespace, "delayed", "Total number of requests that were delayed", constLabels),
-			"rejected":         newLimitRequestMetric(namespace, "rejected", "Total number of requests that were that were rejected", constLabels),
+			"rejected":         newLimitRequestMetric(namespace, "rejected", "Total number of requests that were rejected", constLabels),
 			"delayed_dry_run":  newLimitRequestMetric(namespace, "delayed_dry_run", "Total number of requests accounted as delayed in the dry run mode", constLabels),
 			"rejected_dry_run": newLimitRequestMetric(namespace, "rejected_dry_run", "Total number of requests accounted as rejected in the dry run mode", constLabels),
 		},


### PR DESCRIPTION
Remove a duplicate "that were" in metric description

### Proposed changes
While adding metrics from the README to our grafana dashboards I found a small error in the description. This fixes just that.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
