### PR TITLE
Remove deprecated go linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,6 @@ linters-settings:
 linters:
     enable:
     - asciicheck
-    - deadcode
     - errcheck
     - errorlint
     - gofmt
@@ -50,12 +49,10 @@ linters:
     - promlinter
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - wastedassign
     disable-all: true
 issues:


### PR DESCRIPTION
The linters have not been updated in 3-6 years and have been deprecated.
https://github.com/golangci/golangci-lint/pull/3125

