### PR TITLE
Replace autolabeler with `actions/labeler`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,21 @@
+enhancement:
+- branch: ['feature/**', 'feat/**', 'enhancement/**', 'enh/**']
+
+bug:
+- branch: ['fix/**', 'bug/**']
+
+chore:
+- branch: ['chore/**']
+
+tests:
+- branch: ['tests/**', 'test/**']
+- '**/*_test.go'
+
+docs:
+- branch: ['docs/**', 'doc/**']
+- '**/*.md'
+
+dependencies:
+- branch: ['deps/**', 'dep/**']
+- go.mod
+- go.sum

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,6 +13,9 @@ categories:
   - title: '📝 Documentation'
     labels:
       - "documentation"
+  - title: '🧪 Tests'
+    labels:
+      - "tests"
   - title: '🔨 Maintenance'
     labels:
       - "chore"
@@ -35,32 +38,6 @@ version-resolver:
   default: patch
 exclude-labels:
   - 'skip-changelog'
-autolabeler:
-  - label: 'documentation'
-    files:
-      - '*.md'
-    branch:
-      - '/docs{0,1}\/.+/'
-  - label: 'chore'
-    branch:
-      - '/chore\/.+/'
-  - label: 'bug'
-    branch:
-      - '/fix\/.+/'
-    title:
-      - '/fix/i'
-  - label: 'enhancement'
-    branch:
-      - '/enh\/.+/'
-      - '/enhancement\/.+/'
-      - '/feat\/.+/'
-      - '/feature\/.+/'
-  - label: 'dependencies'
-    files:
-      - 'go.mod'
-      - 'go.sum'
-    branch:
-      - '/deps\/.+/'
 template: |
   ## New in NGINX Prometheus Exporter v$RESOLVED_VERSION
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: joshdales/labeler@0861fa5accbc36878f85f40b98a9f40b15fe0429 # if https://github.com/actions/labeler/pull/203 is merged, use the official action actions/labeler
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,13 +4,16 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - uses: release-drafter/release-drafter@v5
+        with:
+          disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Uses the official `actions/labeler` even if with a new feature not yet merged that can use branch names.
The action can now label PRs coming from forks and has only the required permission to manage the labels.

This is the first step towards removing release-drafter.