### PR TITLE
Update labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,6 +16,6 @@ docs:
 - '**/*.md'
 
 dependencies:
-- branch: ['deps/**', 'dep/**']
+- branch: ['deps/**', 'dep/**', 'dependabot/**']
 - go.mod
 - go.sum


### PR DESCRIPTION
Adds `dependabot/` to the branch names to include PRs from dependabot