### PR TITLE
Add override for HTTP Host header feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ To start the exporter we use the [docker run](https://docs.docker.com/engine/ref
 
 ```
 Usage of ./nginx-prometheus-exporter:
+  -nginx.host-override string
+        Override for HTTP Host header. The default value can be overwritten by HOST_OVERRIDE environment variable.
   -nginx.plus
         Start the exporter for NGINX Plus. By default, the exporter is started for NGINX. The default value can be overwritten by NGINX_PLUS environment variable.
   -nginx.retries int

--- a/exporter.go
+++ b/exporter.go
@@ -229,6 +229,7 @@ var (
 	defaultMetricsPath        = getEnv("TELEMETRY_PATH", "/metrics")
 	defaultNginxPlus          = getEnvBool("NGINX_PLUS", false)
 	defaultScrapeURI          = getEnv("SCRAPE_URI", "http://127.0.0.1:8080/stub_status")
+	defaultHostOverride       = getEnv("HOST_OVERRIDE", "")
 	defaultSslVerify          = getEnvBool("SSL_VERIFY", true)
 	defaultSslCaCert          = getEnv("SSL_CA_CERT", "")
 	defaultSslClientCert      = getEnv("SSL_CLIENT_CERT", "")
@@ -261,6 +262,9 @@ var (
 		defaultScrapeURI,
 		`A URI or unix domain socket path for scraping NGINX or NGINX Plus metrics.
 For NGINX, the stub_status page must be available through the URI. For NGINX Plus -- the API. The default value can be overwritten by SCRAPE_URI environment variable.`)
+	hostOverride = flag.String("nginx.host-override",
+		defaultHostOverride,
+		"Override for HTTP Host header. The default value can be overwritten by HOST_OVERRIDE environment variable.")
 	sslVerify = flag.Bool("nginx.ssl-verify",
 		defaultSslVerify,
 		"Perform SSL certificate verification. The default value can be overwritten by SSL_VERIFY environment variable.")
@@ -407,7 +411,7 @@ func main() {
 		registry.MustRegister(collector.NewNginxPlusCollector(plusClient.(*plusclient.NginxClient), "nginxplus", variableLabelNames, constLabels.labels))
 	} else {
 		ossClient, err := createClientWithRetries(func() (interface{}, error) {
-			return client.NewNginxClient(httpClient, *scrapeURI)
+			return client.NewNginxClient(httpClient, *scrapeURI, *hostOverride)
 		}, *nginxRetries, nginxRetryInterval.Duration)
 		if err != nil {
 			log.Fatalf("Could not create Nginx Client: %v", err)


### PR DESCRIPTION
### Proposed changes
This PR overrides the HTTP Host header value.
Useful when connecting to `/stub_status` on another server block.
This is a modification with the same feature as Apache Exporter(Lusitaniae/apache_exporter#60).

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
