### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Determine GOPATH
         id: go
         run: |
-          echo "::set-output name=go_path::$(go env GOPATH)"
+          echo "go_path=$(go env GOPATH)" >> $GITHUB_OUTPUT
       - name: Setup QEMU
         uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Output Variables
         id: vars
-        run: echo "::set-output name=go_version::$(grep "go 1." go.mod | cut -d " " -f 2)"
+        run: echo "go_version=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_OUTPUT
       - name: Setup Golang Environment
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:


### PR DESCRIPTION
### Proposed changes

Resolve  #367 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo "::set-output name=go_path::$(go env GOPATH)"
```

```yml
run: echo "::set-output name=go_version::$(grep "go 1." go.mod | cut -d " " -f 2)")
```

**TO-BE**

```yml
echo "go_path=$(go env GOPATH)" >> $GITHUB_OUTPUT
```

```yml
run: echo "go_version=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_OUTPUT)
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md) guide
- [ ] I have proven my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have ensured the README is up to date
- [ ] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
