### PR TITLE
Add gitleaks to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,10 @@ repos:
   hooks:
   - id: golangci-lint
     args: [--new-from-patch=/tmp/diff.patch]
+- repo: https://github.com/gitleaks/gitleaks
+  rev: v8.17.0
+  hooks:
+  - id: gitleaks
 
 ci:
   skip: [golang-diff, golangci-lint]


### PR DESCRIPTION
### Proposed changes
Adds `gitleaks`. From the repo:
>Gitleaks is a SAST tool for detecting and preventing hardcoded secrets like passwords, api keys, and tokens in git repos. Gitleaks is an easy-to-use, all-in-one solution for detecting secrets, past or present, in your code.
