### PR TITLE
Deprecate old flag format

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -138,11 +138,21 @@ func main() {
 	kingpin.Flag("prometheus.const-label", "Label that will be used in every metric. Format is label=value. It can be repeated multiple times.").Envar("CONST_LABELS").StringMapVar(&constLabels)
 
 	promlogConfig := &promlog.Config{}
+	logger := promlog.New(promlogConfig)
+
+	// convert deprecated flags to new format
+	for i, arg := range os.Args {
+		if strings.HasPrefix(arg, "-") && len(arg) > 1 {
+			newArg := fmt.Sprintf("-%s", arg)
+			level.Warn(logger).Log("msg", "the flag format is deprecated and will be removed in a future release, please use the new format", "old", arg, "new", newArg)
+			os.Args[i] = newArg
+		}
+	}
+
 	flag.AddFlags(kingpin.CommandLine, promlogConfig)
 	kingpin.Version(version.Print(exporterName))
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
-	logger := promlog.New(promlogConfig)
 
 	level.Info(logger).Log("msg", "Starting nginx-prometheus-exporter", "version", version.Info())
 	level.Info(logger).Log("msg", "Build context", "build_context", version.BuildContext())


### PR DESCRIPTION
### Proposed changes
Converts old flag format to new format and warns users instead of erroring out.

Closes #447 