### PR TITLE
Sign checksum with cosign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     permissions:
       contents: write # for lucacome/draft-release to create/update release draft
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      id-token: write # for OIDC login to AWS ECR
+      id-token: write # for OIDC login to AWS ECR and goreleaser/goreleaser-action to sign artifacts
       packages: write # for docker/build-push-action to push to GHCR
     needs: unit-tests
     steps:
@@ -144,6 +144,11 @@ jobs:
 
       - name: Download Syft
         uses: anchore/sbom-action/download-syft@78fc58e266e87a38d4194b2137a3d4e9bcaf7ca1 # v0.14.3
+        if: github.ref_type == 'tag'
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 # v3.1.1
+        if: github.ref_type == 'tag'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
@@ -183,6 +188,7 @@ jobs:
         with:
           image: nginx/nginx-prometheus-exporter:${{ steps.meta.outputs.version }}
           only-fixed: true
+          add-cpes-if-none: true
 
       - name: Upload scan result to GitHub Security tab
         uses: github/codeql-action/upload-sarif@0ba4244466797eb048eb91a6cd43d5c03ca8bd05 # v2.21.2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,6 +59,18 @@ brews:
       name: nginx-bot
       email: integrations@nginx.com
 
+signs:
+  - cmd: cosign
+    artifacts: checksum
+    output: true
+    certificate: '${artifact}.pem'
+    args:
+      - sign-blob
+      - "--output-signature=${signature}"
+      - "--output-certificate=${certificate}"
+      - "${artifact}"
+      - "--yes"
+
 announce:
   slack:
     enabled: true


### PR DESCRIPTION
### Proposed changes

Adds config to sign artifacts. Since the checksum contains the SHAs of the artifacts, signing the checksums is enough to ensure that the artifacts were not modified.

GoReleaser uses cosign to sign the artifact and uploads `.sig` and `.pem` to the release.
