### PR TITLE
Add metrics from NGINX Plus API version 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,17 @@ Name | Type | Description | Labels
 `nginxplus_cache_bypass_responses_written` | Counter | Total number of cache bypasses written to cache | `cache`
 `nginxplus_cache_bypass_bytes_written` | Counter | Total number of bytes written to cache from cache bypasses | `cache`
 
+#### [Worker](hhttps://nginx.org/en/docs/http/ngx_http_api_module.html#workers)
+
+Name | Type  | Description | Labels
+----|-------|----|------------|
+`nginxplus_worker_connection_accepted` | Counter | The total number of accepted client connections | `id`, `pid` |
+`nginxplus_worker_connection_dropped` | Counter | The total number of accepted client connections | `id`, `pid` |
+`nginxplus_worker_connection_active` | Gauge | The current number of active client connections | `id`, `pid` |
+`nginxplus_worker_connection_idle` | Gauge | The current number of idle client connection | `id`, `pid` |
+`nginxplus_worker_http_requests_total` | Counter | The total number of client requests received by the worker process | `id`, `pid` |
+`nginxplus_worker_http_requests_current` | Gauge | The current number of client requests that are currently being processed by the worker process | `id`, `pid` |
+
 Connect to the `/metrics` page of the running exporter to see the complete list of metrics along with their
 descriptions. Note: to see server zones related metrics you must configure [status
 zones](https://nginx.org/en/docs/http/ngx_http_status_module.html#status_zone) and to see upstream related metrics you

--- a/collector/nginx_plus.go
+++ b/collector/nginx_plus.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/go-kit/log"
@@ -26,6 +27,8 @@ type LabelUpdater interface {
 	DeleteStreamServerZoneLabels(zoneNames []string)
 	UpdateCacheZoneLabels(cacheLabelValues map[string][]string)
 	DeleteCacheZoneLabels(cacheNames []string)
+	UpdateWorkerLabels(workerLabelValues map[string][]string)
+	DeleteWorkerLabels(workerNames []string)
 }
 
 // NginxPlusCollector collects NGINX Plus metrics. It implements prometheus.Collector interface.
@@ -57,6 +60,8 @@ type NginxPlusCollector struct {
 	cacheZoneLabels                map[string][]string
 	variableLabelsMutex            sync.RWMutex
 	logger                         log.Logger
+	workerLabels                   map[string][]string
+	workerMetrics                  map[string]*prometheus.Desc
 }
 
 // UpdateUpstreamServerPeerLabels updates the Upstream Server Peer Labels
@@ -221,6 +226,30 @@ func (c *NginxPlusCollector) getStreamUpstreamServerPeerLabelValues(peer string)
 	return c.streamUpstreamServerPeerLabels[peer]
 }
 
+// UpdateWorkerLabels updates the Worker Labels
+func (c *NginxPlusCollector) UpdateWorkerLabels(workerLabelValues map[string][]string) {
+	c.variableLabelsMutex.Lock()
+	for k, v := range workerLabelValues {
+		c.workerLabels[k] = v
+	}
+	c.variableLabelsMutex.Unlock()
+}
+
+// DeleteWorkerLabels deletes the Worker Labels
+func (c *NginxPlusCollector) DeleteWorkerLabels(id []string) {
+	c.variableLabelsMutex.Lock()
+	for _, k := range id {
+		delete(c.workerLabels, k)
+	}
+	c.variableLabelsMutex.Unlock()
+}
+
+func (c *NginxPlusCollector) getWorkerLabelValues(id string) []string {
+	c.variableLabelsMutex.RLock()
+	defer c.variableLabelsMutex.RUnlock()
+	return c.workerLabels[id]
+}
+
 // VariableLabelNames holds all the variable label names for the different metrics
 type VariableLabelNames struct {
 	UpstreamServerVariableLabelNames           []string
@@ -230,11 +259,12 @@ type VariableLabelNames struct {
 	StreamServerZoneVariableLabelNames         []string
 	StreamUpstreamServerVariableLabelNames     []string
 	CacheZoneLabelNames                        []string
+	WorkerPIDVariableLabelNames                []string
 }
 
-// NewVariableLabels creates a new struct for VariableNames for the collector
+// NewVariableLabelNames NewVariableLabels creates a new struct for VariableNames for the collector
 func NewVariableLabelNames(upstreamServerVariableLabelNames []string, serverZoneVariableLabelNames []string, upstreamServerPeerVariableLabelNames []string,
-	streamUpstreamServerVariableLabelNames []string, streamServerZoneLabels []string, streamUpstreamServerPeerVariableLabelNames []string, cacheZoneLabelNames []string,
+	streamUpstreamServerVariableLabelNames []string, streamServerZoneLabels []string, streamUpstreamServerPeerVariableLabelNames []string, cacheZoneLabelNames []string, workerPIDVariableLabelNames []string,
 ) VariableLabelNames {
 	return VariableLabelNames{
 		UpstreamServerVariableLabelNames:           upstreamServerVariableLabelNames,
@@ -244,6 +274,7 @@ func NewVariableLabelNames(upstreamServerVariableLabelNames []string, serverZone
 		StreamServerZoneVariableLabelNames:         streamServerZoneLabels,
 		StreamUpstreamServerPeerVariableLabelNames: streamUpstreamServerPeerVariableLabelNames,
 		CacheZoneLabelNames:                        cacheZoneLabelNames,
+		WorkerPIDVariableLabelNames:                workerPIDVariableLabelNames,
 	}
 }
 
@@ -543,6 +574,14 @@ func NewNginxPlusCollector(nginxClient *plusclient.NginxClient, namespace string
 			"bypass_responses_written":  newCacheZoneMetric(namespace, "bypass_responses_written", "Total number of cache bypasses written to cache", constLabels),
 			"bypass_bytes_written":      newCacheZoneMetric(namespace, "bypass_bytes_written", "Total number of bytes written to cache from cache bypasses", constLabels),
 		},
+		workerMetrics: map[string]*prometheus.Desc{
+			"connection_accepted":   newWorkerMetric(namespace, "connection_accepted", "The total number of accepted client connections", variableLabelNames.WorkerPIDVariableLabelNames, constLabels),
+			"connection_dropped":    newWorkerMetric(namespace, "connection_dropped", "The total number of dropped client connections", variableLabelNames.WorkerPIDVariableLabelNames, constLabels),
+			"connection_active":     newWorkerMetric(namespace, "connection_active", "The current number of active client connections", variableLabelNames.WorkerPIDVariableLabelNames, constLabels),
+			"connection_idle":       newWorkerMetric(namespace, "connection_idle", "The current number of idle client connections", variableLabelNames.WorkerPIDVariableLabelNames, constLabels),
+			"http_requests_total":   newWorkerMetric(namespace, "http_requests_total", "The total number of client requests received by the worker process", variableLabelNames.WorkerPIDVariableLabelNames, constLabels),
+			"http_requests_current": newWorkerMetric(namespace, "http_requests_current", "The current number of client requests that are currently being processed by the worker process", variableLabelNames.WorkerPIDVariableLabelNames, constLabels),
+		},
 	}
 }
 
@@ -591,6 +630,9 @@ func (c *NginxPlusCollector) Describe(ch chan<- *prometheus.Desc) {
 		ch <- m
 	}
 	for _, m := range c.cacheZoneMetrics {
+		ch <- m
+	}
+	for _, m := range c.workerMetrics {
 		ch <- m
 	}
 }
@@ -1207,6 +1249,28 @@ func (c *NginxPlusCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["bypass_responses_written"], prometheus.CounterValue, float64(zone.Bypass.ResponsesWritten), name)
 		ch <- prometheus.MustNewConstMetric(c.cacheZoneMetrics["bypass_bytes_written"], prometheus.CounterValue, float64(zone.Bypass.BytesWritten), name)
 	}
+
+	for _, worker := range stats.Workers {
+		labelValues := []string{strconv.FormatInt(int64(worker.ID), 10), strconv.FormatInt(int64(worker.ProcessID), 10)}
+		varLabelValues := c.getWorkerLabelValues(strconv.FormatInt(int64(worker.ID), 10))
+
+		if c.variableLabelNames.WorkerPIDVariableLabelNames != nil && len(varLabelValues) != len(c.variableLabelNames.WorkerPIDVariableLabelNames) {
+			level.Warn(c.logger).Log("wrong number of labels for worker %v. For labels %v, got values: %v. Empty labels will be used instead",
+				strconv.FormatInt(int64(worker.ID), 10), c.variableLabelNames.WorkerPIDVariableLabelNames, varLabelValues)
+			for range c.variableLabelNames.WorkerPIDVariableLabelNames {
+				labelValues = append(labelValues, "")
+			}
+		} else {
+			labelValues = append(labelValues, varLabelValues...)
+		}
+
+		ch <- prometheus.MustNewConstMetric(c.workerMetrics["connection_accepted"], prometheus.CounterValue, float64(worker.Connections.Accepted), labelValues...)
+		ch <- prometheus.MustNewConstMetric(c.workerMetrics["connection_dropped"], prometheus.CounterValue, float64(worker.Connections.Dropped), labelValues...)
+		ch <- prometheus.MustNewConstMetric(c.workerMetrics["connection_active"], prometheus.GaugeValue, float64(worker.Connections.Active), labelValues...)
+		ch <- prometheus.MustNewConstMetric(c.workerMetrics["connection_idle"], prometheus.GaugeValue, float64(worker.Connections.Idle), labelValues...)
+		ch <- prometheus.MustNewConstMetric(c.workerMetrics["http_requests_total"], prometheus.CounterValue, float64(worker.HTTP.HTTPRequests.Total), labelValues...)
+		ch <- prometheus.MustNewConstMetric(c.workerMetrics["http_requests_current"], prometheus.GaugeValue, float64(worker.HTTP.HTTPRequests.Current), labelValues...)
+	}
 }
 
 var upstreamServerStates = map[string]float64{
@@ -1280,4 +1344,10 @@ func newStreamLimitConnectionMetric(namespace string, metricName string, docStri
 
 func newCacheZoneMetric(namespace string, metricName string, docString string, constLabels prometheus.Labels) *prometheus.Desc {
 	return prometheus.NewDesc(prometheus.BuildFQName(namespace, "cache", metricName), docString, []string{"zone"}, constLabels)
+}
+
+func newWorkerMetric(namespace string, metricName string, docString string, variableLabelNames []string, constLabels prometheus.Labels) *prometheus.Desc {
+	labels := []string{"id", "pid"}
+	labels = append(labels, variableLabelNames...)
+	return prometheus.NewDesc(prometheus.BuildFQName(namespace, "worker", metricName), docString, labels, constLabels)
 }

--- a/exporter.go
+++ b/exporter.go
@@ -180,7 +180,7 @@ func main() {
 			level.Error(logger).Log("msg", "Could not create Nginx Plus Client", "error", err.Error())
 			os.Exit(1)
 		}
-		variableLabelNames := collector.NewVariableLabelNames(nil, nil, nil, nil, nil, nil, nil)
+		variableLabelNames := collector.NewVariableLabelNames(nil, nil, nil, nil, nil, nil, nil, nil)
 		prometheus.MustRegister(collector.NewNginxPlusCollector(plusClient, "nginxplus", variableLabelNames, constLabels, logger))
 	} else {
 		ossClient := client.NewNginxClient(httpClient, *scrapeURI)


### PR DESCRIPTION
˜### Proposed changes

Add metrics for NGINX worker data, connection accepted, dropped, current active, current idle, http request total and current.

Example NGINX Plus API response /workers/

```
[
    {
        "id": 0,
        "pid": 970577,
        "connections": {
            "accepted": 12364048,
            "dropped": 0,
            "active": 1,
            "idle": 80
        },
        "http": {
            "requests": {
                "total": 21726744,
                "current": 0
            }
        }
    },
    {
        "id": 1,
        "pid": 970578,
        "connections": {
            "accepted": 13538199,
            "dropped": 0,
            "active": 2,
            "idle": 66
        },
        "http": {
            "requests": {
                "total": 22635133,
                "current": 1
            }
        }
    }
]
```

Prometheus metrics for workers
```
# HELP nginxplus_worker_connection_accepted The total number of accepted client connections
# TYPE nginxplus_worker_connection_accepted counter
nginxplus_worker_connection_accepted{id="0",pid="970577"} 1.2363957e+07
nginxplus_worker_connection_accepted{id="1",pid="970578"} 1.3538027e+07
# HELP nginxplus_worker_connection_active The current number of active client connections
# TYPE nginxplus_worker_connection_active gauge
nginxplus_worker_connection_active{id="0",pid="970577"} 2
nginxplus_worker_connection_active{id="1",pid="970578"} 1
# HELP nginxplus_worker_connection_dropped The total number of dropped client connections
# TYPE nginxplus_worker_connection_dropped counter
nginxplus_worker_connection_dropped{id="0",pid="970577"} 0
nginxplus_worker_connection_dropped{id="1",pid="970578"} 0
# HELP nginxplus_worker_connection_idle The current number of idle client connections
# TYPE nginxplus_worker_connection_idle gauge
nginxplus_worker_connection_idle{id="0",pid="970577"} 77
nginxplus_worker_connection_idle{id="1",pid="970578"} 63
# HELP nginxplus_worker_http_requests_current The current number of client requests that are currently being processed by the worker process
# TYPE nginxplus_worker_http_requests_current gauge
nginxplus_worker_http_requests_current{id="0",pid="970577"} 1
nginxplus_worker_http_requests_current{id="1",pid="970578"} 0
# HELP nginxplus_worker_http_requests_total The total number of client requests received by the worker process
# TYPE nginxplus_worker_http_requests_total counter
nginxplus_worker_http_requests_total{id="0",pid="970577"} 2.1726533e+07
nginxplus_worker_http_requests_total{id="1",pid="970578"} 2.2634942e+07
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md)
  guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
