### PR TITLE
Add support for multiple scrape addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Usage of ./nginx-prometheus-exporter:
   -nginx.scrape-uri string
         A URI or unix domain socket path for scraping NGINX or NGINX Plus metrics.
         For NGINX, the stub_status page must be available through the URI. For NGINX Plus -- the API. The default value can be overwritten by SCRAPE_URI environment variable. (default "http://127.0.0.1:8080/stub_status")
+        Configure this option with the URI for every nginx instance to scrape.
   -nginx.ssl-ca-cert string
         Path to the PEM encoded CA certificate file used to validate the servers SSL certificate. The default value can be overwritten by SSL_CA_CERT environment variable.
   -nginx.ssl-client-cert string


### PR DESCRIPTION
### Proposed changes

Make the `nginx.scrape-uri` accept a slice of addresses, and register prometheus collectors for each monitored nginx instance.

This revision came out of a discussion in https://github.com/nginxinc/nginx-prometheus-exporter/issues/229. The general concensus by those in the thread was that it would be better to run an nginx-exporter for every monitored nginx instance. I had implemented these changes for my own use, so I decided to make them available to the wider community here.

Feel free to merge, or don't :-) I'm fine with either.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md)
  guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
