### PR TITLE
Use latest stable version of Go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version-file: go.mod
+          go-version: stable
 
       - name: Run Tests
         run: make test
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version-file: go.mod
+          go-version: stable
 
       - name: Determine GOPATH
         id: go

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version-file: go.mod
+          go-version: stable
 
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
       # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Golang Environment
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version-file: go.mod
+          go-version: stable
 
       - name: Lint Code
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0


### PR DESCRIPTION
### Proposed changes

Since Go changed the versioning in `go.mod` to specify a patch release, we don't use the latest go version when building the binary.
Before with `1.20` in `go.mod` we would use the latest version of `1.20.x`, but now since we specify `1.21.3` in `go.mod` we use that fixed version and not `1.21.4` for example, and future updates. 
`1.21.3` in `go.mod` should be considered a minimum requirement.
