### PR TITLE
Replace deprecated value in GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,7 +45,7 @@ sboms:
       - "${artifact}.spdx.json"
 
 brews:
-  - tap:
+  - repository:
       owner: nginxinc
       name: homebrew-tap
       token: '{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}'


### PR DESCRIPTION
### Proposed changes

`tap` is deprecated and `repository` should be used.