### PR TITLE
Restore the old behavior when 'nginx-prometheus-exporter' was the default rule for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION = 1.1.0
 TAG = $(VERSION)
 PREFIX = nginx/nginx-prometheus-exporter
 
-.DEFAULT_GOAL:=help
+.DEFAULT_GOAL:=nginx-prometheus-exporter
 
 .PHONY: help
 help: Makefile ## Display this help


### PR DESCRIPTION
### Proposed changes

This pull request resolves #620.

In the Makefile, the `help` and `nginx-prometheus-exporter` targets have been swapped, now making `nginx-prometheus-exporter` the default target again. This adjusts the default build command ensuring consistency with the instructions in `README.md`.

Please provide feedback if further changes are needed.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
