### PR TITLE
ci: add gh action workflow definition for F5 CLA automation

### DIFF
--- a/.github/workflows/f5-cla.yml
+++ b/.github/workflows/f5-cla.yml
@@ -1,4 +1,4 @@
-name: "F5 CLA Workflow"
+name: F5 CLA
 on:
   issue_comment:
     types: [created]
@@ -7,29 +7,33 @@ on:
 
 permissions:
   actions: write
-  contents: write
   pull-requests: write
   statuses: write
 
 jobs:
   f5-cla:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - name: "F5 CLA Assistant"
+      - name: Run F5 CLA assistant
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have hereby read the F5 CLA and agree to its terms') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.3.0
+        uses: contributor-assistant/github-action@dbc1c64d82d3aad5072007a41fff2828ae6d23ec # v2.3.2
+        with:
+          # Any pull request targeting the following branch will trigger a CLA check
+          branch: 'main'
+          # Path to the CLA document
+          path-to-document: 'https://github.com/f5/.github/blob/main/CLA/cla-markdown.md'
+          # Custom CLA messages
+          custom-notsigned-prcomment: '🎉 Thank you for your contribution. It appears you have not yet signed the F5 Contributor License Agreement (CLA), which is required for your changes to be incorporated into an F5 project. Please kindly read the [F5 CLA](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md) and comment the following to agree:'
+          custom-pr-sign-comment: 'I have hereby read the F5 CLA and agree to its terms'
+          custom-allsigned-prcomment: '✅ All required contributors have signed the F5 CLA for this PR. Thank you!'
+          # Remote repository storing CLA signatures
+          remote-organization-name: 'f5'
+          remote-repository-name: 'f5-cla-data'
+          path-to-signatures: 'signatures/beta/signatures.json'
+          # Comma seperated list of usernames for maintainers or any other individuals who should not be prompted for a CLA.
+          allowlist: Dean-Coakley, pleshakov, lucacome, bot*
+          # Do not lock PRs after a merge
+          lock-pullrequest-aftermerge: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.F5_CLA_TOKEN }}
-        with:
-          path-to-signatures: 'signatures/beta/signatures.json'
-          path-to-document: 'https://github.com/f5/.github/blob/main/CLA/cla-markdown.md'
-          # Any pull request targeting the following branch will trigger a CLA check
-          branch: 'main'
-          custom-pr-sign-comment: 'I have hereby read the F5 CLA and agree to its terms'
-          custom-notsigned-prcomment: '🎉 Thank you for your contribution. It appears you have not yet signed the F5 Contributor License Agreement, which is required for your changes to be incorporated into an F5 project. Please kindly read the [F5 CLA](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md) and comment the following to agree:'
-          custom-allsigned-prcomment: 'All required contributors have signed the F5 CLA for this PR  ✅'
-          remote-organization-name: 'f5'
-          remote-repository-name: 'f5-cla-data'
-          # Comma seperated list of usernames for maintainers or any other individuals who should not be prompted for a CLA.
-          allowlist: Dean-Coakley, pleshakov, lucacome, bot*

--- a/.github/workflows/f5-cla.yml
+++ b/.github/workflows/f5-cla.yml
@@ -1,0 +1,35 @@
+name: "F5 CLA Workflow"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  f5-cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "F5 CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have hereby read the F5 CLA and agree to its terms') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.F5_CLA_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/beta/signatures.json'
+          path-to-document: 'https://github.com/f5/.github/blob/main/CLA/cla-markdown.md'
+          # Any pull request targeting the following branch will trigger a CLA check
+          branch: 'main'
+          custom-pr-sign-comment: 'I have hereby read the F5 CLA and agree to its terms'
+          custom-notsigned-prcomment: '🎉 Thank you for your contribution. It appears you have not yet signed the F5 Contributor License Agreement, which is required for your changes to be incorporated into an F5 project. Please kindly read the [F5 CLA](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md) and comment the following to agree:'
+          custom-allsigned-prcomment: 'All required contributors have signed the F5 CLA for this PR  ✅'
+          remote-organization-name: 'f5'
+          remote-repository-name: 'f5-cla-data'
+          # Comma seperated list of usernames for maintainers or any other individuals who should not be prompted for a CLA.
+          allowlist: Dean-Coakley, pleshakov, lucacome, bot*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,11 @@ issue template.
 ### Open a Pull Request
 
 - Fork the repo, create a branch, submit a PR when your changes are tested and ready for review
+- Acknowledge the F5 Contributor License Agreement (CLA) if prompted
+  - F5 Open Source Policy ***requires*** all external contributors agree to the terms outlined in the
+    [F5 CLA](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md) before their changes can be incorporated into
+    an open source project.
+  - If you have not yet signed an F5 CLA when opening a pull request, our tooling will help walk you through the process.
 - Fill in [our pull request template](.github/PULL_REQUEST_TEMPLATE.md)
 
 > **Note**


### PR DESCRIPTION
### Proposed changes

Adds a GH action workflow file (`.github/workflows/f5-cla.yml`) for F5 contributor license agreement (CLA) automation and compliance. This action is configured to target a shared signature store for F5 Open Source projects and will prompt contributors, upon pull request to `main`, to sign the F5 CLA if they have not already done so. 

As part of the configuration for this project, the following GitHub usernames were whitelisted as maintainers:

* `Dean-Coakley`
* `pleshakov` 
* `lucacome`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md)
  guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
