### PR TITLE
Add GitHub Action workflow for F5 CLA integration

### DIFF
--- a/.github/workflows/f5-cla.yml
+++ b/.github/workflows/f5-cla.yml
@@ -1,0 +1,40 @@
+---
+name: F5 CLA
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+permissions: read-all
+jobs:
+  f5-cla:
+    name: F5 CLA
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: write
+      pull-requests: write
+      statuses: write
+    steps:
+      - name: Run F5 Contributor License Agreement (CLA) assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have hereby read the F5 CLA and agree to its terms') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@9340315624c6e16cef1f2c63bdeb0f0c49c6f474 # v2.4.0
+        with:
+          # Any pull request targeting the following branch will trigger a CLA check.
+          branch: 'main'
+          # Path to the CLA document.
+          path-to-document: 'https://github.com/f5/.github/blob/main/CLA/cla-markdown.md'
+          # Custom CLA messages.
+          custom-notsigned-prcomment: '🎉 Thank you for your contribution! It appears you have not yet signed the F5 Contributor License Agreement (CLA), which is required for your changes to be incorporated into an F5 Open Source Software (OSS) project. Please kindly read the [F5 CLA](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md) and reply on a new comment with the following text to agree:'
+          custom-pr-sign-comment: 'I have hereby read the F5 CLA and agree to its terms'
+          custom-allsigned-prcomment: '✅ All required contributors have signed the F5 CLA for this PR. Thank you!'
+          # Remote repository storing CLA signatures.
+          remote-organization-name: 'f5'
+          remote-repository-name: 'f5-cla-data'
+          path-to-signatures: 'signatures/beta/signatures.json'
+          # Comma separated list of usernames for maintainers or any other individuals who should not be prompted for a CLA.
+          allowlist: lucacome, pleshakov, bot*
+          # Do not lock PRs after a merge.
+          lock-pullrequest-aftermerge: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.F5_CLA_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,16 @@ issue template.
   type of issue it is (bug, feature request, etc) and to determine the milestone. Please see the [Issue
   Lifecycle](ISSUE_LIFECYCLE.md) document for more information.
 
+### F5 Contributor License Agreement (CLA)
+
+F5 requires all external contributors to agree to the terms of the F5 CLA
+(available [here](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)) before any of their changes can be
+incorporated into an F5 Open Source repository.
+
+If you have not yet agreed to the F5 CLA terms and submit a PR to this repository, a bot will prompt you to view and
+agree to the F5 CLA. You will have to agree to the F5 CLA terms through a comment in the PR before any of your changes
+can be merged. Your agreement signature will be safely stored by F5 and no longer be required in future PRs.
+
 ## Style Guides
 
 ### Git Style Guide


### PR DESCRIPTION
### Proposed changes

An updated version of #661 that includes a GitHub action workflow integrating the F5 CLA into the typical GitHub pull-request flow for individual contributors.

As part of this workflow's configuration, the following usernames were marked as F5 maintainers:

* `lucacome`
* `pleshakov` 


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
