### PR TITLE
Build for more platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - main
 
 env:
-  DOCKER_PLATFORMS: "linux/arm,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x,linux/mips64le,linux/386"
+  DOCKER_PLATFORMS: "linux/arm/v5,linux/arm/v6,linux/arm/v7,linux/arm64,linux/amd64,linux/ppc64le,linux/s390x,linux/mips64le,linux/386,linux/riscv64"
 
 concurrency:
   group: ${{ github.ref_name }}-ci
@@ -51,6 +51,11 @@ jobs:
       packages: write # for docker/build-push-action to push to GHCR
       issues: write # for goreleaser/goreleaser-action to close milestones
     needs: unit-tests
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -64,14 +69,12 @@ jobs:
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
-        with:
-          platforms: arm,arm64,ppc64le,s390x,mips64le,386
-        if: github.event_name != 'pull_request'
 
       - name: Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
         with:
           version: latest
+          driver-opts: network=host
 
       - name: DockerHub Login
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
@@ -114,15 +117,17 @@ jobs:
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: |
-            nginx/nginx-prometheus-exporter
-            ghcr.io/nginxinc/nginx-prometheus-exporter
-            public.ecr.aws/nginx/nginx-prometheus-exporter
-            quay.io/nginx/nginx-prometheus-exporter
+            name=nginx/nginx-prometheus-exporter,enable=${{ github.event_name != 'pull_request' }}
+            name=ghcr.io/nginxinc/nginx-prometheus-exporter,enable=${{ github.event_name != 'pull_request' }}
+            name=public.ecr.aws/nginx/nginx-prometheus-exporter,enable=${{ github.event_name != 'pull_request' }}
+            name=quay.io/nginx/nginx-prometheus-exporter,enable=${{ github.event_name != 'pull_request' }}
+            name=localhost:5000/nginx/nginx-prometheus-exporter
           tags: |
             type=edge
             type=ref,event=pr
             type=schedule
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
           labels: |
             org.opencontainers.image.vendor=NGINX Inc <integrations@nginx.com>
@@ -175,7 +180,7 @@ jobs:
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
           version: v2.2.0 # renovate: datasource=github-tags depName=goreleaser/goreleaser
-          args: ${{ github.ref_type == 'tag' && 'release' || 'build --snapshot' }} ${{ github.event_name == 'pull_request' && '--single-target' || '' }} --clean
+          args: ${{ github.ref_type == 'tag' && 'release' || 'build --snapshot' }} --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NGINX_GITHUB_TOKEN: ${{ secrets.NGINX_PAT }}
@@ -192,23 +197,23 @@ jobs:
           file: build/Dockerfile
           context: "."
           target: goreleaser
-          platforms: ${{ github.event_name != 'pull_request' && env.DOCKER_PLATFORMS || '' }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          annotations: ${{ github.event_name != 'pull_request' && steps.meta.outputs.annotations || '' }}
-          load: ${{ github.event_name == 'pull_request' }}
-          push: ${{ github.event_name != 'pull_request' }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: ${{ github.event_name != 'pull_request' && 'mode=max' || 'false' }}
-          sbom: ${{ github.event_name != 'pull_request' }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          push: true
+          cache-from: type=gha,scope=exporter
+          cache-to: type=gha,scope=exporter,mode=max
+          no-cache: ${{ github.event_name != 'pull_request' }}
+          provenance: mode=max
+          sbom: true
 
       - name: Scan image
         uses: anchore/scan-action@64a33b277ea7a1215a3c142735a1091341939ff5 # v4.1.2
         id: scan
         continue-on-error: true
         with:
-          image: nginx/nginx-prometheus-exporter:${{ steps.meta.outputs.version }}
+          image: localhost:5000/nginx/nginx-prometheus-exporter:${{ steps.meta.outputs.version }}
           only-fixed: true
           add-cpes-if-none: true
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,16 +8,21 @@ builds:
   - env:
       - CGO_ENABLED=0
     goos:
-      - linux
       - darwin
+      - freebsd
+      - linux
+      - solaris
       - windows
     goarch:
       - 386
       - amd64
       - arm
       - arm64
-      - ppc64le
+      - mips64
       - mips64le
+      - ppc64
+      - ppc64le
+      - riscv64
       - s390x
     goarm:
       - 5
@@ -88,9 +93,6 @@ announce:
 
 milestones:
   - close: true
-
-snapshot:
-  name_template: "edge"
 
 snapcrafts:
   - name_template: "{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,21 +1,24 @@
 # syntax=docker/dockerfile:1.9
-FROM golang:1.23 AS base
+FROM golang:1.23 AS builder
 ARG VERSION
 ARG TARGETARCH
 
 WORKDIR /go/src/github.com/nginxinc/nginx-prometheus-exporter
 
-FROM base AS builder
 COPY --link go.mod go.sum ./
 RUN go mod download
+
 COPY --link *.go ./
 COPY --link collector ./collector
 COPY --link client ./client
+
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath -a -ldflags "-s -w -X main.version=${VERSION}" -o nginx-prometheus-exporter .
 
 
+FROM --platform=$BUILDPLATFORM alpine:3.20 AS certs
+
 FROM scratch AS intermediate
-COPY --from=base --link /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=certs --link /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 USER 1001:1001
 ENTRYPOINT [ "/usr/bin/nginx-prometheus-exporter" ]
 
@@ -32,4 +35,4 @@ ARG TARGETPLATFORM
 LABEL org.nginx.exporter.image.build.target="${TARGETPLATFORM}"
 LABEL org.nginx.exporter.image.build.version="goreleaser"
 
-COPY --link dist/nginx-prometheus-exporter_linux_$TARGETARCH${TARGETVARIANT:+_7}*/nginx-prometheus-exporter /usr/bin/
+COPY --link dist/nginx-prometheus-exporter_linux_$TARGETARCH${TARGETVARIANT/v/_}*/nginx-prometheus-exporter /usr/bin/


### PR DESCRIPTION
### Proposed changes

Debian builds packages for `ppc64` and  `riscv64`. Alpine supports `mips64`.
NGINX runs on `freebsd` and `solaris`.
This PR adds support for all those architectures and platforms.
It also adds docker builds for all variants of arm and `riscv64`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md) guide
- [ ] I have proven my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have ensured the README is up to date
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
