### PR TITLE
Use timeout flag for context cancelation

### DIFF
--- a/client/nginx.go
+++ b/client/nginx.go
@@ -47,10 +47,7 @@ func NewNginxClient(httpClient *http.Client, apiEndpoint string) *NginxClient {
 }
 
 // GetStubStats fetches the stub_status metrics.
-func (client *NginxClient) GetStubStats() (*StubStats, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
+func (client *NginxClient) GetStubStats(ctx context.Context) (*StubStats, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, client.apiEndpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a get request: %w", err)

--- a/exporter.go
+++ b/exporter.go
@@ -220,9 +220,7 @@ func main() {
 	_ = srv.Shutdown(srvCtx)
 }
 
-func registerCollector(logger *slog.Logger, transport *http.Transport,
-	addr string, labels map[string]string,
-) {
+func registerCollector(logger *slog.Logger, transport *http.Transport, addr string, labels map[string]string) {
 	if strings.HasPrefix(addr, "unix:") {
 		socketPath, requestPath, err := parseUnixSocketAddress(addr)
 		if err != nil {
@@ -239,7 +237,6 @@ func registerCollector(logger *slog.Logger, transport *http.Transport,
 	userAgent := fmt.Sprintf("NGINX-Prometheus-Exporter/v%v", common_version.Version)
 
 	httpClient := &http.Client{
-		Timeout: *timeout,
 		Transport: &userAgentRoundTripper{
 			agent: userAgent,
 			rt:    transport,
@@ -253,10 +250,10 @@ func registerCollector(logger *slog.Logger, transport *http.Transport,
 			os.Exit(1)
 		}
 		variableLabelNames := collector.NewVariableLabelNames(nil, nil, nil, nil, nil, nil, nil)
-		prometheus.MustRegister(collector.NewNginxPlusCollector(plusClient, "nginxplus", variableLabelNames, labels, logger))
+		prometheus.MustRegister(collector.NewNginxPlusCollector(plusClient, "nginxplus", variableLabelNames, labels, logger, *timeout))
 	} else {
 		ossClient := client.NewNginxClient(httpClient, addr)
-		prometheus.MustRegister(collector.NewNginxCollector(ossClient, "nginx", labels, logger))
+		prometheus.MustRegister(collector.NewNginxCollector(ossClient, "nginx", labels, logger, *timeout))
 	}
 }
 


### PR DESCRIPTION
### Proposed changes

This pull request introduces several changes to the NGINX Prometheus exporter to add context and timeout handling capabilities. The main updates include modifying the `GetStubStats` method to accept a context parameter, adding a timeout field to the `NginxCollector` and `NginxPlusCollector` structs, and updating the `Collect` methods to use context with timeout.

### Context and Timeout Handling Enhancements:

* [`client/nginx.go`](diffhunk://#diff-3863b59ca5529c5061594d2486ec29224d282b86c9315b179370477057342d68L50-R50): Modified the `GetStubStats` method to accept a `context.Context` parameter, enabling more flexible request handling.

* `collector/nginx.go`: 
  * Added `context` and `time` imports to support context with timeout.
  * Added a `timeout` field to the `NginxCollector` struct and updated the `NewNginxCollector` function to accept a timeout parameter.
  * Updated the `Collect` method to use a context with timeout for fetching stub stats.

* `collector/nginx_plus.go`: 
  * Added `time` import to support context with timeout.
  * Added a `timeout` field to the `NginxPlusCollector` struct and updated the `NewNginxPlusCollector` function to accept a timeout parameter. [[1]](diffhunk://#diff-b59b3ada0e29598117bd0eac38ed5000b05f1819cb27eb34ce298110e3009f6aL34-L38) [[2]](diffhunk://#diff-b59b3ada0e29598117bd0eac38ed5000b05f1819cb27eb34ce298110e3009f6aL50-R61) [[3]](diffhunk://#diff-b59b3ada0e29598117bd0eac38ed5000b05f1819cb27eb34ce298110e3009f6aL259-R261) [[4]](diffhunk://#diff-b59b3ada0e29598117bd0eac38ed5000b05f1819cb27eb34ce298110e3009f6aR278)
  * Updated the `Collect` method to use a context with timeout for fetching NGINX Plus stats.

### Code Cleanup:

* `exporter.go`: 
  * Simplified the `registerCollector` function signature and removed the `Timeout` field from the `http.Client` configuration. [[1]](diffhunk://#diff-e4987a222ab3e846614998485952d8ee42288062a30929290cf3ea0e815d5ae1L223-R223) [[2]](diffhunk://#diff-e4987a222ab3e846614998485952d8ee42288062a30929290cf3ea0e815d5ae1L242) [[3]](diffhunk://#diff-e4987a222ab3e846614998485952d8ee42288062a30929290cf3ea0e815d5ae1L256-R256)

Closes #858

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md) guide
- [ ] I have proven my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have ensured the README is up to date
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
