### PR TITLE
Specify patch version for go docker image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.17
-FROM golang:1.24 AS builder
+FROM golang:1.24.5 AS builder
 ARG VERSION
 ARG TARGETARCH
 


### PR DESCRIPTION
### Proposed changes

Specifying the patch version of the go docker image should allow renovate to propose version updates for patch version that ca contain security updates like it is the case for go 1.21.4 --> 1.24.4 which fixes some non major CVE


Fixes #1090 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md) guide
- [ ] I have proven my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
