### PR TITLE
Fix error condition in v2 proxy support

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -281,7 +281,7 @@ func registerCollector(logger *slog.Logger, transport *http.Transport,
 
 			// as we do not use any TLVs, header size should be pretty small, hence we only check for error, assuming the whole header went out in a single packet
 			_, err = header.WriteTo(conn)
-			if err == nil {
+			if err != nil {
 				conn.Close()
 				return nil, fmt.Errorf("writing proxyproto header via %s to %s: %w", network, addr, err)
 			}


### PR DESCRIPTION
### Proposed changes

This PR fixes an error condition that seems to have been introduced in https://github.com/nginx/nginx-prometheus-exporter/pull/979/commits/cbaa06821ed396a076c9456f5492a841d92d587d.

#### Tests

Following the tests from #979, I see the following error which is consistent with the error condition:

```
./nginx-prometheus-exporter \
  --nginx.proxy-protocol \
  --nginx.scrape-uri="http://127.0.0.1:18080/stub_status" \
  --web.listen-address=":9116" \
  --web.telemetry-path="/metrics"
time=2025-10-08T08:50:46.977+02:00 level=INFO source=exporter.go:126 msg=nginx-prometheus-exporter version="(version=, branch=, revision=064e74611406c672b3c2403bcdd55cd24d47876d-modified)"
time=2025-10-08T08:50:46.978+02:00 level=INFO source=exporter.go:127 msg="build context" build_context="(go=go1.25.0, platform=darwin/arm64, user=, date=, tags=unknown)"
time=2025-10-08T08:50:46.979+02:00 level=INFO source=tls_config.go:346 msg="Listening on" address=[::]:9116
time=2025-10-08T08:50:46.979+02:00 level=INFO source=tls_config.go:349 msg="TLS is disabled." http2=false address=[::]:9116
time=2025-10-08T08:51:17.609+02:00 level=ERROR source=nginx.go:57 msg="error getting stats" error="failed to get http://127.0.0.1:18080/stub_status: Get \"http://127.0.0.1:18080/stub_status\": round trip failed: writing proxyproto header via tcp to 127.0.0.1:18080: %!w(<nil>)"
```

With the change in this PR I can successfully run through the series of tests outlined in #979. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginx/nginx-prometheus-exporter/blob/main/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have ensured the README is up to date
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch on my own fork
