### PR TITLE
added Host header option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 1.5.0
+VERSION = 1.5.1
 TAG = $(VERSION)
 PREFIX = nginx/nginx-prometheus-exporter
 # renovate: datasource=github-tags depName=golangci/golangci-lint

--- a/client/nginx.go
+++ b/client/nginx.go
@@ -18,6 +18,7 @@ Reading: %d Writing: %d Waiting: %d
 type NginxClient struct {
 	httpClient  *http.Client
 	apiEndpoint string
+	hostHeader  string
 }
 
 // StubStats represents NGINX stub_status metrics.
@@ -37,10 +38,11 @@ type StubConnections struct {
 }
 
 // NewNginxClient creates an NginxClient.
-func NewNginxClient(httpClient *http.Client, apiEndpoint string) *NginxClient {
+func NewNginxClient(httpClient *http.Client, apiEndpoint string, hostHeader string) *NginxClient {
 	client := &NginxClient{
 		apiEndpoint: apiEndpoint,
 		httpClient:  httpClient,
+		hostHeader:  hostHeader,
 	}
 
 	return client
@@ -55,6 +57,11 @@ func (client *NginxClient) GetStubStats() (*StubStats, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a get request: %w", err)
 	}
+
+	if len(client.hostHeader) > 0 {
+		req.Host = client.hostHeader
+	}
+
 	resp, err := client.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get %v: %w", client.apiEndpoint, err)


### PR DESCRIPTION
### Proposed changes

In my setup using Bunkerweb, the 'internal' HTTP calls to the stub_status endpoint where blocked by the different security features of Bunkerweb. Only by specifying the Host in the header, nginx_exporter was able to reach the stub_status endpoint


